### PR TITLE
extracted name package.xml to global variable

### DIFF
--- a/src/catkin_pkg/package.py
+++ b/src/catkin_pkg/package.py
@@ -42,10 +42,12 @@ import re
 import sys
 import xml.dom.minidom as dom
 
+PACKAGE_MANIFEST_FILENAME = 'package.xml'
+
 
 class Package(object):
     """
-    Object representation of a ``package.xml`` file
+    Object representation of a package manifest file
     """
     __slots__ = [
         'package_format',
@@ -296,11 +298,11 @@ def parse_package(path):
     if os.path.isfile(path):
         filename = path
     elif os.path.isdir(path):
-        filename = os.path.join(path, 'package.xml')
+        filename = os.path.join(path, PACKAGE_MANIFEST_FILENAME)
         if not os.path.isfile(filename):
-            raise IOError('Directory "%s" does not contain a "package.xml"' % (path))
+            raise IOError('Directory "%s" does not contain a "%s"' % (path, PACKAGE_MANIFEST_FILENAME))
     else:
-        raise IOError('Path "%s" is neither a directory containing a "package.xml" file nor a file' % (path))
+        raise IOError('Path "%s" is neither a directory containing a "%s" file nor a file' % (path, PACKAGE_MANIFEST_FILENAME))
 
     with open(filename, 'r') as f:
         try:

--- a/src/catkin_pkg/package_templates.py
+++ b/src/catkin_pkg/package_templates.py
@@ -36,7 +36,7 @@ import sys
 import os
 from string import Template
 
-from catkin_pkg.package import Package
+from catkin_pkg.package import Package, PACKAGE_MANIFEST_FILENAME
 
 
 class PackageTemplate(Package):
@@ -85,7 +85,7 @@ def create_package_files(target_path, package_template, newfiles):
     :param package_template: contains the required information
     :param newfiles: dict {filepath: file_contents_str}
     """
-    newfiles[os.path.join(target_path, 'package.xml')] = create_package_xml(package_template)
+    newfiles[os.path.join(target_path, PACKAGE_MANIFEST_FILENAME)] = create_package_xml(package_template)
     create_files(newfiles, target_path)
 
 

--- a/src/catkin_pkg/packages.py
+++ b/src/catkin_pkg/packages.py
@@ -35,23 +35,23 @@ Library to find packages in the filesystem.
 """
 
 import os
-from .package import parse_package
+from .package import parse_package, PACKAGE_MANIFEST_FILENAME
 
 
 def find_package_paths(basepath):
     """
-    Crawls the filesystem to find package.xml files.
+    Crawls the filesystem to find package manifest files.
 
     When a subfolder contains a file ``CATKIN_NO_SUBDIRS`` its
     subdirectories are ignored.
 
     :param basepath: The path to search in, ``str``
-    :returns: A list of relative paths containing package.xml files
+    :returns: A list of relative paths containing package manifest files
     ``list``
     """
     paths = []
     for dirpath, dirnames, filenames in os.walk(basepath, followlinks=True):
-        if 'package.xml' in filenames:
+        if PACKAGE_MANIFEST_FILENAME in filenames:
             basename = os.path.basename(dirpath)
             if basename not in paths:
                 paths.append(os.path.relpath(dirpath, basepath))
@@ -68,7 +68,7 @@ def find_package_paths(basepath):
 
 def find_packages(basepath):
     """
-    Crawls the filesystem to find package.xml files and parses them.
+    Crawls the filesystem to find package manifest files and parses them.
 
     :param basepath: The path to search in, ``str``
     :returns: A dict mapping relative paths to ``Package`` objects

--- a/test/test_templates.py
+++ b/test/test_templates.py
@@ -8,7 +8,7 @@ from mock import MagicMock, Mock
 from catkin_pkg.package_templates import create_files, create_package_files, \
     create_package_xml, PackageTemplate
 from catkin_pkg.package import parse_package_for_distutils, parse_package, \
-    Dependency, Export, Url
+    Dependency, Export, Url, PACKAGE_MANIFEST_FILENAME
 
 
 class TemplateTest(unittest.TestCase):
@@ -56,7 +56,7 @@ class TemplateTest(unittest.TestCase):
         try:
             rootdir = tempfile.mkdtemp()
             file1 = os.path.join(rootdir, 'CMakeLists.txt')
-            file2 = os.path.join(rootdir, 'package.xml')
+            file2 = os.path.join(rootdir, PACKAGE_MANIFEST_FILENAME)
             create_package_files(rootdir, pack, {file1: ''})
             self.assertTrue(os.path.isfile(file1))
             self.assertTrue(os.path.isfile(file2))
@@ -75,7 +75,7 @@ class TemplateTest(unittest.TestCase):
                                licenses=['BSD'])
         try:
             rootdir = tempfile.mkdtemp()
-            file2 = os.path.join(rootdir, 'package.xml')
+            file2 = os.path.join(rootdir, PACKAGE_MANIFEST_FILENAME)
             create_package_files(rootdir, pack, {})
             self.assertTrue(os.path.isfile(file2))
 
@@ -149,7 +149,7 @@ class TemplateTest(unittest.TestCase):
 
         try:
             rootdir = tempfile.mkdtemp()
-            file2 = os.path.join(rootdir, 'package.xml')
+            file2 = os.path.join(rootdir, PACKAGE_MANIFEST_FILENAME)
             create_package_files(rootdir, pack, {})
             self.assertTrue(os.path.isfile(file2))
 


### PR DESCRIPTION
This to be used also in catkin and any other tool.
Using a global allows compile time detection of typos.
