### PR TITLE
fix python3 bytes/str bug in Person

### DIFF
--- a/src/catkin_pkg/package.py
+++ b/src/catkin_pkg/package.py
@@ -205,7 +205,7 @@ class Person(object):
         if self.email is not None:
             return '%s <%s>' % (self.name.encode('utf-8'), self.email)
         else:
-            return self.name.encode('utf-8')
+            return '%s' % self.name.encode('utf-8')
 
     def validate(self):
         if self.email is None:


### PR DESCRIPTION
`__str__()` should return a type `str()` not `bytes()`

python3:

```
from catkin_pkg.package import Person
p=Person('plop')
str(p)
```

error:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: __str__ returned non-string (type bytes)
```
