### PR TITLE
Handle windows paths nicely for cmake

### DIFF
--- a/src/catkin_pkg/cmake.py
+++ b/src/catkin_pkg/cmake.py
@@ -44,7 +44,7 @@ def get_metapackage_cmake_template_path():
     :returns: ``str`` location of the metapackage CMakeLists.txt CMake template
     '''
     rel_path = os.path.join('templates', 'groovy', 'metapackage.cmake.in')
-    return os.path.join(os.path.dirname(__file__), rel_path)
+    return os.path.join(os.path.dirname(__file__), rel_path).replace('\\','/')
 
 
 def configure_file(template_file, environment):


### PR DESCRIPTION
Make sure paths handed off to cmake (in this case `catkin/cmake/em/order_packages.cmake.em`) are given proper cmake paths (always forward slashes), otherwise cmake falls over trying to parse invalid escape sequences and you get the error of the kind below.

```
-- Using CATKIN_TEST_RESULTS_DIR: C:/work/ws/build/test_results
-- catkin 0.5.64
-- BUILD_SHARED_LIBS is on
CMake Error at C:/work/ws/build/catkin_generated/order_packages.cmake:58 (set):
  Syntax error in cmake code at

    C:/work/ws/build/catkin_generated/order_packages.cmake:58

  when parsing string

    C:\Python27\lib\site-packages\catkin_pkg\templates\groovy\metapackage.cmake.in

  Invalid escape sequence \P
Call Stack (most recent call first):
  catkin/cmake/catkin_workspace.cmake:35 (include)
  CMakeLists.txt:51 (catkin_workspace)


-- Configuring incomplete, errors occurred!
```
