### PR TITLE
Metapackage validation

### DIFF
--- a/src/catkin_pkg/metapackage.py
+++ b/src/catkin_pkg/metapackage.py
@@ -1,0 +1,164 @@
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2013, Open Source Robotics Foundation, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Open Source Robotics Foundation, Inc. nor
+#    the names of its contributors may be used to endorse or promote
+#    products derived from this software without specific prior
+#    written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""
+Checks metapackages for compliance with REP-0127:
+
+http://ros.org/reps/rep-0127.html#metapackage
+"""
+
+from __future__ import print_function
+
+import os
+import sys
+
+from catkin_pkg.cmake import get_metapackage_cmake_template_path
+from catkin_pkg.cmake import configure_file
+
+__author__ = "William Woodall"
+__email__ = "william@osrfoundation.org"
+__maintainer__ = "William Woodall"
+
+DEFINITION_URL = 'http://ros.org/reps/rep-0127.html#metapackage'
+
+
+class InvalidMetapackage(Exception):
+    def __init__(self, msg, path, package):
+        self.path = path
+        self.package = package
+        Exception.__init__(self, "Metapackage '%s': %s" % (package.name, msg))
+
+
+def get_expected_cmakelists_txt(metapackage_name):
+    """
+    Returns the expected boilerplate CMakeLists.txt file for a metapackage
+
+    :param metapackage_name: name of the metapackage
+    :type metapackage_name: str
+    :returns: expected CMakeLists.txt file
+    :rtype: str
+    """
+    env = {
+        'name': metapackage_name,
+        'metapackage_arguments': ''
+    }
+    return configure_file(get_metapackage_cmake_template_path(), env)
+
+
+def has_cmakelists_txt(path):
+    """
+    Returns True if the given path contains a CMakeLists.txt, otherwise False
+
+    :param path: path to folder potentially containing CMakeLists.txt
+    :type path: str
+    :returns: True if path contains CMakeLists.txt, else False
+    :rtype: bool
+    """
+    cmakelists_txt_path = os.path.join(path, 'CMakeLists.txt')
+    return os.path.isfile(cmakelists_txt_path)
+
+
+def get_cmakelists_txt(path):
+    """
+    Fetches the CMakeLists.txt from a given path
+
+    :param path: path to the folder containing the CMakeLists.txt
+    :type path: str
+    :returns: contents of CMakeLists.txt file in given path
+    :rtype: str
+    :raises OSError: if there is no CMakeLists.txt in given path
+    """
+    cmakelists_txt_path = os.path.join(path, 'CMakeLists.txt')
+    with open(cmakelists_txt_path, 'r') as f:
+        return f.read()
+
+
+def has_valid_cmakelists_txt(path, metapackage_name):
+    """
+    Returns True if the given path contains a valid CMakeLists.txt, otherwise False
+
+    A valid CMakeLists.txt for a metapackage is defined by REP-0127
+
+    :param path: path to folder containing CMakeLists.txt
+    :type path: str
+    :param metapackage_name: name of the metapackage being tested
+    :type metapackage_name: str
+    :returns: True if the path contains a valid CMakeLists.txt, else False
+    :rtype: bool
+    :raises OSError: if there is no CMakeLists.txt in given path
+    """
+    cmakelists_txt = get_cmakelists_txt(path)
+    expected = get_expected_cmakelists_txt(metapackage_name)
+    return cmakelists_txt == expected
+
+
+def validate_metapackage(path, package):
+    """
+    Validates the given package (catkin_pkg.package.Package) as a metapackage
+
+    This validates the metapackage against the definition from REP-0127
+
+    :param path: directory of the package being checked
+    :type path: str
+    :param package: package to be validated
+    :type package: :py:class:`catkin_pkg.package.Package`
+    :raises InvalidMetapackage: if package is not a valid metapackage
+    :raises OSError: if there is not package.xml at the given path
+    """
+    # Is there actually a package at the given path, else raise
+    # Cannot do package_exists_at from catkin_pkg.packages because of circular dep
+    if not os.path.isdir(path) or not os.path.isfile(os.path.join(path, 'package.xml')):
+        raise OSError("No package.xml found at path: '%s'" % path)
+    # Is it a metapackage, else raise
+    if not package.is_metapackage():
+        raise InvalidMetapackage('No <metapackage/> tag in <export> section of package.xml', path, package)
+    # Is there a CMakeLists.txt, else raise
+    if not has_cmakelists_txt(path):
+        raise InvalidMetapackage('No CMakeLists.txt', path, package)
+    # Is the CMakeLists.txt correct, else raise
+    if not has_valid_cmakelists_txt(path, package.name):
+        raise InvalidMetapackage("""\
+Invalid CMakeLists.txt
+Expected:
+%s
+Got:
+%s""" % (get_cmakelists_txt(path), get_expected_cmakelists_txt(package.name)), path, package
+        )
+    # Does it buildtool depend on catkin, else raise
+    if not package.has_buildtool_depend_on_catkin():
+        raise InvalidMetapackage("No buildtool dependency on catkin", path, package)
+    # Does it have only run depends, else raise
+    if package.has_invalid_metapackage_dependencies():
+        raise InvalidMetapackage(
+            "Has build, buildtool, and/or test depends, but only run depends are allowed (except buildtool catkin)",
+            path, package)

--- a/test/data/metapackages/invalid_cmake/CMakeLists.txt
+++ b/test/data/metapackages/invalid_cmake/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(invalid_cmake)
+find_package(catkin REQUIRED)
+catkin_package()

--- a/test/data/metapackages/invalid_cmake/package.xml
+++ b/test/data/metapackages/invalid_cmake/package.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<package>
+  <name>invalid_cmake</name>
+  <version>0.1.0</version>
+  <description>invalid_cmake</description>
+
+  <maintainer email="user@todo.todo">user</maintainer>
+  <license>BSD</license>
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <run_depend>foo</run_depend>
+  <run_depend>bar</run_depend>
+  <run_depend>baz</run_depend>
+
+  <export>
+    <metapackage/>
+  </export>
+
+</package>

--- a/test/data/metapackages/invalid_depends/CMakeLists.txt
+++ b/test/data/metapackages/invalid_depends/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(invalid_depends)
+find_package(catkin REQUIRED)
+catkin_metapackage()

--- a/test/data/metapackages/invalid_depends/package.xml
+++ b/test/data/metapackages/invalid_depends/package.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<package>
+  <name>invalid_depends</name>
+  <version>0.1.0</version>
+  <description>invalid_depends</description>
+
+  <maintainer email="user@todo.todo">user</maintainer>
+  <license>BSD</license>
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <run_depend>foo</run_depend>
+  <run_depend>bar</run_depend>
+  <run_depend>baz</run_depend>
+
+  <build_depend>ping</build_depend>
+
+  <export>
+    <metapackage/>
+  </export>
+
+</package>

--- a/test/data/metapackages/leftover_files/CMakeLists.txt
+++ b/test/data/metapackages/leftover_files/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(leftover_files)
+find_package(catkin REQUIRED)
+catkin_metapackage()

--- a/test/data/metapackages/leftover_files/Makefile
+++ b/test/data/metapackages/leftover_files/Makefile
@@ -1,0 +1,1 @@
+all: echo 'not supposed to be here'

--- a/test/data/metapackages/leftover_files/package.xml
+++ b/test/data/metapackages/leftover_files/package.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<package>
+  <name>leftover_files</name>
+  <version>0.1.0</version>
+  <description>leftover_files</description>
+
+  <maintainer email="user@todo.todo">user</maintainer>
+  <license>BSD</license>
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <run_depend>foo</run_depend>
+  <run_depend>bar</run_depend>
+  <run_depend>baz</run_depend>
+
+  <export>
+    <metapackage/>
+  </export>
+
+</package>

--- a/test/data/metapackages/no_buildtool_depend_catkin/CMakeLists.txt
+++ b/test/data/metapackages/no_buildtool_depend_catkin/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(no_buildtool_depend_catkin)
+find_package(catkin REQUIRED)
+catkin_metapackage()

--- a/test/data/metapackages/no_buildtool_depend_catkin/package.xml
+++ b/test/data/metapackages/no_buildtool_depend_catkin/package.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<package>
+  <name>no_buildtool_depend_catkin</name>
+  <version>0.1.0</version>
+  <description>no_buildtool_depend_catkin</description>
+
+  <maintainer email="user@todo.todo">user</maintainer>
+  <license>BSD</license>
+
+  <run_depend>foo</run_depend>
+  <run_depend>bar</run_depend>
+  <run_depend>baz</run_depend>
+
+  <export>
+    <metapackage/>
+  </export>
+
+</package>

--- a/test/data/metapackages/no_cmake/package.xml
+++ b/test/data/metapackages/no_cmake/package.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<package>
+  <name>no_cmake</name>
+  <version>0.1.0</version>
+  <description>no_cmake</description>
+
+  <maintainer email="user@todo.todo">user</maintainer>
+  <license>BSD</license>
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <run_depend>foo</run_depend>
+  <run_depend>bar</run_depend>
+  <run_depend>baz</run_depend>
+
+  <export>
+    <metapackage/>
+  </export>
+
+</package>

--- a/test/data/metapackages/no_metapackage_tag/CMakeLists.txt
+++ b/test/data/metapackages/no_metapackage_tag/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(no_metapackage_tag)
+find_package(catkin REQUIRED)
+catkin_metapackage()

--- a/test/data/metapackages/no_metapackage_tag/package.xml
+++ b/test/data/metapackages/no_metapackage_tag/package.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<package>
+  <name>no_metapackage_tag</name>
+  <version>0.1.0</version>
+  <description>no_metapackage_tag</description>
+
+  <maintainer email="user@todo.todo">user</maintainer>
+  <license>BSD</license>
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <run_depend>foo</run_depend>
+  <run_depend>bar</run_depend>
+  <run_depend>baz</run_depend>
+
+</package>

--- a/test/data/metapackages/valid_metapackage/CMakeLists.txt
+++ b/test/data/metapackages/valid_metapackage/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(valid_metapackage)
+find_package(catkin REQUIRED)
+catkin_metapackage()

--- a/test/data/metapackages/valid_metapackage/package.xml
+++ b/test/data/metapackages/valid_metapackage/package.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<package>
+  <name>valid_metapackage</name>
+  <version>0.1.0</version>
+  <description>valid_metapackage</description>
+
+  <maintainer email="user@todo.todo">user</maintainer>
+  <license>BSD</license>
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <run_depend>foo</run_depend>
+  <run_depend>bar</run_depend>
+  <run_depend>baz</run_depend>
+
+  <export>
+    <metapackage/>
+  </export>
+
+</package>

--- a/test/test_metapackage.py
+++ b/test/test_metapackage.py
@@ -1,0 +1,84 @@
+from __future__ import print_function
+
+import contextlib
+import os
+import re
+import StringIO
+import sys
+import unittest
+
+from catkin_pkg.metapackage import get_expected_cmakelists_txt
+from catkin_pkg.metapackage import InvalidMetapackage
+from catkin_pkg.metapackage import validate_metapackage
+
+from catkin_pkg.packages import find_packages
+
+test_data_dir = os.path.join(os.path.dirname(__file__), 'data', 'metapackages')
+
+test_expectations = {
+    # Test name: [ExceptionType or None, ExceptionRegex or None, WarningRegex or None]
+    'invalid_cmake': [InvalidMetapackage, 'Invalid CMakeLists.txt', None],
+    'invalid_depends': [InvalidMetapackage, 'Has build, buildtool, and/or test depends', None],
+    'leftover_files': [None, None, None],
+    'no_buildtool_depend_catkin': [InvalidMetapackage, 'No buildtool dependency on catkin', None],
+    'no_cmake': [InvalidMetapackage, 'No CMakeLists.txt', None],
+    'no_metapackage_tag': [InvalidMetapackage, 'No <metapackage/> tag in <export>', None],
+    'valid_metapackage': [None, None, None]
+}
+
+
+@contextlib.contextmanager
+def assert_warning(warnreg):
+    orig_stdout = sys.stdout
+    orig_stderr = sys.stderr
+    try:
+        out = StringIO.StringIO()
+        sys.stdout = out
+        sys.stderr = sys.stdout
+        yield
+    finally:
+        if warnreg is not None:
+            out = out.getvalue()
+            assert re.search(warnreg, out) is not None, "'%s' does not match warning '%s'" % (warnreg, out)
+        else:
+            print(out)
+        sys.stdout = orig_stdout
+        sys.stderr = orig_stderr
+
+
+def _validate_metapackage(path, package):
+    try:
+        validate_metapackage(path, package)
+    except Exception:
+        # print('on package ' + package.name, file=sys.stderr)
+        raise
+
+
+class TestMetapackageValidation(unittest.TestCase):
+    """Tests the metapackage validator"""
+    def test_validate_metapackage(self):
+        pkgs_dict = find_packages(test_data_dir)
+        for path, package in pkgs_dict.iteritems():
+            path = os.path.join(test_data_dir, path)
+            assert package.name in test_expectations, 'Unknown test %s' % package.name
+            exc, excreg, warnreg = test_expectations[package.name]
+            with assert_warning(warnreg):
+                if exc is not None:
+                    if excreg is not None:
+                        with self.assertRaisesRegexp(exc, excreg):
+                            _validate_metapackage(path, package)
+                    else:
+                        with self.assertRaises(exc):
+                            _validate_metapackage(path, package)
+                else:
+                    _validate_metapackage(path, package)
+
+
+def test_get_expected_cmakelists_txt():
+    expected = '''\
+cmake_minimum_required(VERSION 2.8.3)
+project(example)
+find_package(catkin REQUIRED)
+catkin_metapackage()
+'''
+    assert expected == get_expected_cmakelists_txt('example')


### PR DESCRIPTION
Added a module for metapackage validation.

I plan to use this in `catkin_prepare_release` and `bloom`.

`catkin_make` and `catkin_make_isolated` should probably also use it in order to have consistent checking. I modularized it as much as possible so that different failure levels could be achieved by different tools.
