### PR TITLE
Two fixes for package xml exports

### DIFF
--- a/src/catkin_pkg/package_templates.py
+++ b/src/catkin_pkg/package_templates.py
@@ -421,8 +421,8 @@ def create_package_xml(package_template, rosdistro):
                       '%s' % (export.content),
                       file=sys.stderr)
             else:
-                attribs = ['%s="%s"' % (k, v) for (k, v) in export.attributes]
-                line = '    <%s%s/>\n' % (export.tagname, ''.join(attribs))
+                attribs = ['%s="%s"' % (k, v) for (k, v) in export.attributes.items()]
+                line = '    <%s %s/>\n' % (export.tagname, ' '.join(attribs))
                 exports.append(line)
     temp_dict['exports'] = ''.join(exports)
 


### PR DESCRIPTION
Without the .items() you have the error:

```
[error] too many values to unpack : <type 'exceptions.ValueError'>
```

The space also makes sure the tag and attributes are separated.
