### PR TITLE
Made find_package dependencies be listed on separate lines

### DIFF
--- a/src/catkin_pkg/package_templates.py
+++ b/src/catkin_pkg/package_templates.py
@@ -237,7 +237,7 @@ def create_cmakelists(package_template, rosdistro):
     if package_template.catkin_deps == []:
         components = ''
     else:
-        components = ' COMPONENTS\n  %s\n  ' % '\n  '.join(package_template.catkin_deps)
+        components = ' COMPONENTS\n  %s\n' % '\n  '.join(package_template.catkin_deps)
     has_include_folder = 'roscpp' in package_template.catkin_deps
     boost_find_package = \
         ('' if not package_template.boost_comps

--- a/test/test_templates.py
+++ b/test/test_templates.py
@@ -47,7 +47,7 @@ class TemplateTest(unittest.TestCase):
         expected = """find_package(catkin REQUIRED COMPONENTS
   bar
   baz
-  )"""
+)"""
         
         self.assertTrue(expected in result, result)
 


### PR DESCRIPTION
This changes the appearance of CMakeLists.txt when you run `catkin_create_pkg`:

Instead of:

```
find_package(catkin REQUIRED COMPONENTS ros_control ros_controllers roscpp)
```

It will now appear as:

```
find_package(catkin REQUIRED COMPONENTS
  ros_control
  ros_controllers
  roscpp
)
```

This is good because:
- Diffs will be more useful - show just the dep added/removed not the whole line
- Listing them on separate lines is common practice from my experience and will save ppl the time of splitting them up manually
- Is easier to read/scan for certain dependencies than a horizontal list.
