### PR TITLE
Added sub folder for cpp header files of package names namespace

### DIFF
--- a/src/catkin_pkg/package_templates.py
+++ b/src/catkin_pkg/package_templates.py
@@ -211,7 +211,7 @@ def create_package_files(target_path, package_template, rosdistro,
         newfiles[cmake_path] = create_cmakelists(package_template, rosdistro)
     _safe_write_files(newfiles, target_path)
     if 'roscpp' in package_template.catkin_deps:
-        fname = os.path.join(target_path, 'include')
+        fname = os.path.join(target_path, 'include/' + package_template.name)
         os.makedirs(fname)
         print('Created folder %s' % os.path.relpath(fname, os.path.dirname(target_path)))
     if 'roscpp' in package_template.catkin_deps or \


### PR DESCRIPTION
I've seen almost everywhere that the standard for adding cpp header files is to put them within a sub folder of the include folder, named after the package itself. This PR adds proper folder name spacing when creating new catkin packages.
