### PR TITLE
Fixes #65 with python 2/3 compatibility

### DIFF
--- a/src/catkin_pkg/package_templates.py
+++ b/src/catkin_pkg/package_templates.py
@@ -185,7 +185,10 @@ def _safe_write_files(newfiles, target_dir):
             os.makedirs(dirname)
         # print(target_file, content)
         with open(target_file, 'ab') as fhand:
-            fhand.write(content)
+            if sys.version < '3':
+                fhand.write(content)
+            else:
+                fhand.write(bytes(content,'UTF-8'))
         print('Created file %s' % os.path.relpath(target_file, os.path.dirname(target_dir)))
 
 


### PR DESCRIPTION
Solves the:
TypeError: 'str' does not support the buffer interface
referenced in #65

Tested with python 3.3.1
