### PR TITLE
Use wiki.ros.org for default URL for a package.xml template that gets generated by catkin_create_pkg.

### DIFF
--- a/src/catkin_pkg/templates/package.xml.in
+++ b/src/catkin_pkg/templates/package.xml.in
@@ -17,7 +17,7 @@
   <!-- Url tags are optional, but mutiple are allowed, one per tag -->
   <!-- Optional attribute type can be: website, bugtracker, or repository -->
   <!-- Example: -->
-  <!-- <url type="website">http://ros.org/wiki/@name</url> -->
+  <!-- <url type="website">http://wiki.ros.org/@name</url> -->
 @urls
 
   <!-- Author tags are optional, mutiple are allowed, one per tag -->


### PR DESCRIPTION
Although `ros.org/wiki` nicely redirects to the new `wiki.ros.org`, using direct url should be even eco-friendlier.
