### PR TITLE
fix for #77 Catch TypeError in addition to ValueError in the case of an invalid string.

### DIFF
--- a/src/catkin_pkg/changelog.py
+++ b/src/catkin_pkg/changelog.py
@@ -292,7 +292,7 @@ def version_and_date_from_title(title):
     version, date_str = match.groups()
     try:
         date = dateutil.parser.parse(date_str)
-    except ValueError as e:
+    except (ValueError, TypeError) as e:
         # Catch invalid dates
         log.debug("Error parsing date ({0}): '{1}'".format(date_str, e))
         raise InvalidSectionTitle(title)


### PR DESCRIPTION
Different implementations seem to throw the other one. This is reproducably
failing on Travis, but not locally.
