### PR TITLE
Package xml validation

### DIFF
--- a/src/catkin_pkg/package.py
+++ b/src/catkin_pkg/package.py
@@ -199,6 +199,8 @@ class Package(object):
 
         if not self.licenses:
             errors.append('The package node must contain at least one "license" tag')
+        if [l for l in self.licenses if not l.strip()]:
+            errors.append('The license tag must neither be empty nor only contain whitespaces')
 
         if self.authors is not None:
             for author in self.authors:


### PR DESCRIPTION
Based on discussion ros-infrastructure/rep#77.

All released packages in G/H/I are still parsable.

Some of them will show the "version convention" warning:
- Groovy
  - libcsm
  - libg2o
- Hydro
  - libg2o
  - ompl
- Indigo
  - libg2o

@tfoote @wjwwood Please review.
