### PR TITLE
catkin_generate_changelog fails for mercurial repo

### DIFF
--- a/src/catkin_pkg/changelog_generator_vcs.py
+++ b/src/catkin_pkg/changelog_generator_vcs.py
@@ -283,7 +283,7 @@ class HgClient(VcsClientBase):
         return tags
 
     def get_latest_tag_name(self):
-        cmd_log = [HgClient._executable, 'log', '--rev', '.', '--template', '{latesttagdistance}']
+        cmd_log = [self._executable, 'log', '--rev', '.', '--template', '{latesttagdistance}']
         result_log = self._run_command(cmd_log)
         if result_log['returncode']:
             raise RuntimeError('Could not fetch latest tag:\n%s' % result_log['output'])


### PR DESCRIPTION
fails when running `catkin_generate_changelog` for mercurial packages with following error:

```
Found packages: multisense, multisense_bringup, multisense_cal_check, multisense_description, multisense_lib, multisense_ros
Querying commit information since latest tag...
Traceback (most recent call last):
  File "/usr/bin/catkin_generate_changelog", line 120, in <module>
    main()
  File "/usr/bin/catkin_generate_changelog", line 104, in main
    tag2log_entries = get_forthcoming_changes(vcs_client)
  File "/usr/lib/pymodules/python2.7/catkin_pkg/changelog_generator.py", line 68, in get_forthcoming_changes
    latest_tag_name = _get_latest_version_tag_name(vcs_client)
  File "/usr/lib/pymodules/python2.7/catkin_pkg/changelog_generator.py", line 93, in _get_latest_version_tag_name
    tag_name = vcs_client.get_latest_tag_name()
  File "/usr/lib/pymodules/python2.7/catkin_pkg/changelog_generator_vcs.py", line 286, in get_latest_tag_name
    cmd_log = [HgClient._executable, 'log', '--rev', '.', '--template', '{latesttagdistance}']
AttributeError: type object 'HgClient' has no attribute '_executable'
```

Most likely a typo, where `HgClient._executable` should have been `self._executable`.
