### PR TITLE
Added the --meta option to catkin_create_pkg to generate metapackage files. closes #115

### DIFF
--- a/bin/catkin_create_pkg
+++ b/bin/catkin_create_pkg
@@ -16,6 +16,9 @@ def main(argv=sys.argv[1:], parent_path=os.getcwd()):
     parser.add_argument('name',
                         nargs=1,
                         help='The name for the package')
+    parser.add_argument('--meta',
+                        action='store_true',
+                        help='Creates meta-package files')
     parser.add_argument('dependencies',
                         nargs='*',
                         help='Catkin package Dependencies')
@@ -61,7 +64,8 @@ def main(argv=sys.argv[1:], parent_path=os.getcwd()):
         create_package_files(target_path=target_path,
                              package_template=package_template,
                              rosdistro=args.rosdistro,
-                             newfiles={})
+                             newfiles={},
+                             meta=args.meta)
         print('Successfully created files in %s. Please adjust the values in package.xml.' % target_path)
     except ValueError as vae:
         parser.error(str(vae))

--- a/src/catkin_pkg/templates/package.xml.in
+++ b/src/catkin_pkg/templates/package.xml.in
@@ -41,9 +41,6 @@
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>
-    <!-- You can specify that this package is a metapackage here: -->
-    <!-- <metapackage/> -->
-
     <!-- Other tools can request additional information be placed here -->
 @exports
   </export>


### PR DESCRIPTION
This PR adds the `--meta` option to the `catkin_create_pkg` script to generate files of a meta-package.

Only file creation functions were modified to account for the new argument and select the appropriate templates (`CMakeLists.txt`) and variables to export (`package.xml`). The new argument is boolean and is optional.
