### PR TITLE
[metapackage.py] Add print a check item for metapkg validation.

### DIFF
--- a/src/catkin_pkg/metapackage.py
+++ b/src/catkin_pkg/metapackage.py
@@ -147,7 +147,7 @@ def validate_metapackage(path, package):
     # Is the CMakeLists.txt correct, else raise
     if not has_valid_cmakelists_txt(path, package.name):
         raise InvalidMetapackage("""\
-Invalid CMakeLists.txt
+Invalid CMakeLists.txt. Check if the file ends with a line break.
 Expected:
 %s
 Got:


### PR DESCRIPTION
`catkin_prepare_release` fails when a CMakeLists.txt in metapackage doesn't end with an empty line with the following output, from which the cause of failure is unclear.

```
$ catkin_prepare_release 
Prepare the source repository for a release.
Repository type: git
Found packages: force_torque_tools, gravity_compensation, force_torque_sensor_calib
Invalid metapackage at path '/home/rospasta/kth-ros-pkg/force_torque_tools/force_torque_tools':
  Metapackage 'force_torque_tools': Invalid CMakeLists.txt
Expected:
cmake_minimum_required(VERSION 2.8.3)
project(force_torque_tools)
find_package(catkin REQUIRED)
catkin_metapackage()
Got:
cmake_minimum_required(VERSION 2.8.3)
project(force_torque_tools)
find_package(catkin REQUIRED)
catkin_metapackage()


See requirements for metapackages: http://ros.org/reps/rep-0127.html#metapackage
```
This PR adds a print message to give a hint of the possible error.