### PR TITLE
add dynamic reconfigure example and use exported targets in generated CMake template

### DIFF
--- a/src/catkin_pkg/templates/CMakeLists.txt.in
+++ b/src/catkin_pkg/templates/CMakeLists.txt.in
@@ -24,10 +24,10 @@ find_package(catkin REQUIRED@components)
 ## * Let MSG_DEP_SET be the set of packages whose message types you use in
 ##   your messages/services/actions (e.g. std_msgs, actionlib_msgs, ...).
 ## * In the file package.xml:
+##   * add a build_depend tag for "message_generation"
 ##   * add a build_depend and a run_depend tag for each package in MSG_DEP_SET
-##   * If MSG_DEP_SET isn't empty the following dependencies might have been
-##     pulled in transitively but can be declared for certainty nonetheless:
-##     * add a build_depend tag for "message_generation"
+##   * If MSG_DEP_SET isn't empty the following dependency has been pulled in
+##     but can be declared for certainty nonetheless:
 ##     * add a run_depend tag for "message_runtime"
 ## * In this file (CMakeLists.txt):
 ##   * add "message_generation" and every package in MSG_DEP_SET to
@@ -66,6 +66,26 @@ find_package(catkin REQUIRED@components)
 @message_dependencies
 # )
 
+################################################
+## Declare ROS dynamic reconfigure parameters ##
+################################################
+
+## To declare and build dynamic reconfigure parameters within this
+## package, follow these steps:
+## * In the file package.xml:
+##   * add a build_depend and a run_depend tag for "dynamic_reconfigure"
+## * In this file (CMakeLists.txt):
+##   * add "dynamic_reconfigure" to
+##     find_package(catkin REQUIRED COMPONENTS ...)
+##   * uncomment the "generate_dynamic_reconfigure_options" section below
+##     and list every .cfg file to be processed
+
+## Generate dynamic reconfigure parameters in the 'cfg' folder
+# generate_dynamic_reconfigure_options(
+#   cfg/DynReconf1.cfg
+#   cfg/DynReconf2.cfg
+# )
+
 ###################################
 ## catkin specific configuration ##
 ###################################
@@ -90,17 +110,22 @@ catkin_package(
 ## Your package locations should be listed before other locations
 @include_directories
 
-## Declare a cpp library
+## Declare a C++ library
 # add_library(@{name}
 #   src/${PROJECT_NAME}/@name.cpp
 # )
 
-## Declare a cpp executable
+## Add cmake target dependencies of the library
+## as an example, code may need to be generated before libraries
+## either from message generation or dynamic reconfigure
+# add_dependencies(@{name} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
+## Declare a C++ executable
 # add_executable(@{name}_node src/@{name}_node.cpp)
 
-## Add cmake target dependencies of the executable/library
-## as an example, message headers may need to be generated before nodes
-# add_dependencies(@{name}_node @{name}_generate_messages_cpp)
+## Add cmake target dependencies of the executable
+## same as for the library above
+# add_dependencies(@{name}_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 ## Specify libraries to link a library or executable target against
 # target_link_libraries(@{name}_node


### PR DESCRIPTION
This adds example code for `dynamic_reconfigure`. @esteve Please check that the example code and instructions are correct.

Additionally the CMake template uses the exported targets rather then the `_generate_messages_cpp` target to address #79.

@esteve @tfoote @wjwwood Please review.