### PR TITLE
do not write merged log

### DIFF
--- a/src/catkin_pkg/changelog_generator_vcs.py
+++ b/src/catkin_pkg/changelog_generator_vcs.py
@@ -176,6 +176,7 @@ class GitClient(VcsClientBase):
         if from_tag or to_tag:
             cmd.append('%s%s' % ('%s..' % to_tag if to_tag else '', from_tag if from_tag else ''))
         cmd.append('--format=format:%H')
+        cmd.append('--no-merges')
         result = self._run_command(cmd)
         if result['returncode']:
             raise RuntimeError('Could not fetch commit hashes:\n%s' % result['output'])


### PR DESCRIPTION
we usually develop package based on PR as follows
```
*   58caf79 Merge pull request #103 from k-okada/support_jade
|\  
| * 9b0e2bb [travis.sh] Add jade for travis test
| * 8b53695 now jsk_common has been split
| * eeda9f3 [.travis.yml] add test code to check jade environment
|/  
*   889eedc Merge pull request #101 from k-okada/add_source
|\  
| * 4b708fa [travis.sh] source setup.bash before catkin
|/  
*   c1f1a63 Merge pull request #100 from k-okada/add_rospack
|\  
| * dc955e6 [travis.sh] travis.sh need rospack command
|/  
* 063904c 0.0.4
* 971dccc update CHANGELOG
*   196c627 Merge pull request #99 from k-okada/support_before_scrept
```
and when we run `catkin_generate_changelog`, it generate CHANGELOG.rst with many `Merged pull request`... log line as follows
```
@@ -2,6 +2,21 @@
 Changelog for package jsk_travis
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Merge pull request #103 from k-okada/support_jade
+  [.travis.yml] add test code to check jade environment
+* [travis.sh] Add jade for travis test
+* now jsk_common has been split
+* [.travis.yml] add test code to check jade environment
+* Merge pull request #101 from k-okada/add_source
+  [travis.sh] source setup.bash before catkin
+* [travis.sh] source setup.bash before catkin
+* Merge pull request #100 from k-okada/add_rospack
+  [travis.sh] travis.sh need rospack command
+* [travis.sh] travis.sh need rospack command
+* Contributors: Kei Okada, Kentaro Wada
+
 0.0.4 (2015-06-01)
 ------------------
* [.travis.yml] fix BEFORE_SCRIPT for test
```
I always have to remove these lines manually, and this PR will do same job automatically, thus it outpus CHANGELOG as
```
@@ -2,6 +2,15 @@
 Changelog for package jsk_travis
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* [travis.sh] Add jade for travis test
+* now jsk_common has been split
+* [.travis.yml] add test code to check jade environment
+* [travis.sh] source setup.bash before catkin
+* [travis.sh] travis.sh need rospack command
+* Contributors: Kei Okada, Kentaro Wada
+
 0.0.4 (2015-06-01)
 ------------------
 * [.travis.yml] fix BEFORE_SCRIPT for test
```