### PR TITLE
Use macros in doc Makefile

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,10 +1,12 @@
 .PHONY: html apidoc clean upload
 
+SPHINXAPIDOC=sphinx-apidoc
+
 html: apidoc
-	make -C _build html
+	$(MAKE) -C _build html
 
 apidoc:
-	sphinx-apidoc -F -o _build ../src/catkin_pkg
+	$(SPHINXAPIDOC) -F -o _build ../src/catkin_pkg
 	sed -i "s/_build/./g" _build/Makefile
 
 clean:


### PR DESCRIPTION
Using a macro to hold `sphinx-apidoc` allows the command to be overridden when `make` is invoked, for example, to utilize the python3 version of `sphinx-apidoc`, `sphinx-apidoc-3.4`. The macro for `sphinx-build` is already set up this way when `_build/Makefile` is created.

Using `$(MAKE)` instead of simply calling `make` ensures that the same command is used when chaining (where this could be something like `gmake`), and also negotiates any parallelism available in the top level call (ie, `-j4`). This is standard practice when chaining `Makefile`s.

Thanks,

--scott