### PR TITLE
Replacing @name with ${PROJECT_NAME}

### DIFF
--- a/src/catkin_pkg/templates/CMakeLists.txt.in
+++ b/src/catkin_pkg/templates/CMakeLists.txt.in
@@ -111,24 +111,24 @@ catkin_package(
 @include_directories
 
 ## Declare a C++ library
-# add_library(@{name}
+# add_library(${PROJECT_NAME}
 #   src/${PROJECT_NAME}/@name.cpp
 # )
 
 ## Add cmake target dependencies of the library
 ## as an example, code may need to be generated before libraries
 ## either from message generation or dynamic reconfigure
-# add_dependencies(@{name} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+# add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 ## Declare a C++ executable
-# add_executable(@{name}_node src/@{name}_node.cpp)
+# add_executable(${PROJECT_NAME}_node src/@{name}_node.cpp)
 
 ## Add cmake target dependencies of the executable
 ## same as for the library above
-# add_dependencies(@{name}_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+# add_dependencies(${PROJECT_NAME}_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 ## Specify libraries to link a library or executable target against
-# target_link_libraries(@{name}_node
+# target_link_libraries(${PROJECT_NAME}_node
 @target_libraries# )
 
 #############
@@ -146,7 +146,7 @@ catkin_package(
 # )
 
 ## Mark executables and/or libraries for installation
-# install(TARGETS @{name} @{name}_node
+# install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}_node
 #   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
 #   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
 #   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}


### PR DESCRIPTION
Replacing almost all occurrences of @name with ${PROJECT_NAME} in order to make changes of the package name easier to handle. The only places (excluding the project's name line at the top of the CMakeLists.txt) where @name is still used are the source files. This will prevent changes to name of project affect the default source files defined in the CMakeLists.txt.