### PR TITLE
Fix KeyError in os.environ['CATKIN_PREFIX_PATH']

### DIFF
--- a/src/catkin_pkg/workspaces.py
+++ b/src/catkin_pkg/workspaces.py
@@ -50,7 +50,7 @@ def get_spaces(paths=None):
     if paths is None:
         if 'CMAKE_PREFIX_PATH' not in os.environ:
             raise RuntimeError('Neither the environment variable CMAKE_PREFIX_PATH is set nor was a list of paths passed.')
-        paths = os.environ['CMAKE_PREFIX_PATH'].split(os.pathsep) if os.environ['CMAKE_PREFIX_PATH'] else []
+        paths = os.environ['CMAKE_PREFIX_PATH'].split(os.pathsep) if 'CMAKE_PREFIX_PATH' in os.environ else []
 
     spaces = []
     for path in paths:


### PR DESCRIPTION
Fix KeyError in os.environ['CATKIN_PREFIX_PATH'] under both python2.7 and python3.4