### PR TITLE
Fixes #130.

### DIFF
--- a/src/catkin_pkg/changelog_generator_vcs.py
+++ b/src/catkin_pkg/changelog_generator_vcs.py
@@ -146,11 +146,11 @@ class GitClient(VcsClientBase):
         return result['output']
 
     def get_tags(self):
-        cmd_tag = [self._executable, 'tag']
+        cmd_tag = [self._executable, 'log', '--simplify-by-decoration', '--pretty="%d"']
         result_tag = self._run_command(cmd_tag)
         if result_tag['returncode']:
             raise RuntimeError('Could not fetch tags:\n%s' % result_tag['output'])
-        tag_names = result_tag['output'].splitlines()
+        tag_names = re.findall("(?<=tag: )([^)]+)", result_tag['output'])
 
         tags = []
         for tag_name in tag_names:

--- a/src/catkin_pkg/changelog_generator_vcs.py
+++ b/src/catkin_pkg/changelog_generator_vcs.py
@@ -150,7 +150,7 @@ class GitClient(VcsClientBase):
         result_tag = self._run_command(cmd_tag)
         if result_tag['returncode']:
             raise RuntimeError('Could not fetch tags:\n%s' % result_tag['output'])
-        tag_names = re.findall("(?<=tag: )([^)]+)", result_tag['output'])
+        tag_names = re.findall('tag: ([^),]+)[),]', result_tag['output'])
 
         tags = []
         for tag_name in tag_names:


### PR DESCRIPTION
When generating a changelog, only tags that are ancestors of the current HEAD
should be included in the changelog. The previous behavior of
`catkin_generate_changelogs --all` was to make changelog entries for every tag
in the repository.

This commit changes the behavior of GitClient.get_tags() such that only
ancestors of the current HEAD are returned.