### PR TITLE
Remove picky warning about leading zeros

### DIFF
--- a/src/catkin_pkg/package.py
+++ b/src/catkin_pkg/package.py
@@ -184,8 +184,6 @@ class Package(object):
             errors.append('Package version must not be empty')
         elif not re.match('^[0-9]+\.[0-9]+\.[0-9]+$', self.version):
             errors.append('Package version "%s" does not follow version conventions' % self.version)
-        elif not re.match('^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$', self.version):
-            new_warnings.append('Package "%s" does not follow the version conventions. It should not contain leading zeros (unless the number is 0).' % self.name)
 
         if not self.description:
             errors.append('Package description must not be empty')


### PR DESCRIPTION
OMPL uses ``<version>1.0.0003094</version>`` which seems like it should be ok but we always get warnings