### PR TITLE
Always read package files as utf8 on python3.

### DIFF
--- a/src/catkin_pkg/package.py
+++ b/src/catkin_pkg/package.py
@@ -365,7 +365,13 @@ def parse_package(path, warnings=None):
     else:
         raise IOError('Path "%s" is neither a directory containing a "%s" file nor a file' % (path, PACKAGE_MANIFEST_FILENAME))
 
-    with open(filename, 'r') as f:
+    # Force utf8 encoding for python3.
+    # This way unicode files can still be processed on non-unicode locales.
+    kwargs = {}
+    if sys.version_info.major >= 3:
+        kwargs['encoding'] = 'utf8'
+
+    with open(filename, 'r', **kwargs) as f:
         try:
             return parse_package_string(f.read(), filename, warnings=warnings)
         except InvalidPackage as e:


### PR DESCRIPTION
This PR forces files to be treated as UTF-8 on python3. This avoids breaking down on non-utf8 locales for `package.xml` files containing unicode.

I personally encountered this when building in a chroot. While I arguably should fix the locale of the chroot, it is not good to depend on the locale for properly parsing `package.xml` files.

This PR should fix ros-infrastructure/rosdep#309