### PR TITLE
allow for "revision" in package version and changelog

### DIFF
--- a/src/catkin_pkg/changelog.py
+++ b/src/catkin_pkg/changelog.py
@@ -295,7 +295,7 @@ def version_and_date_from_title(title):
     :returns: ``(str, datetime.datetime)``
     :raises: ``InvalidSectionTitle`` for non REP-0132 section titles
     '''
-    match = re.search(r'^([0-9]+\.[0-9]+\.[0-9]+)[ ]\((.+)\)$', title)
+    match = re.search(r'^([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9]+[a-z]+)?)[ ]\((.+)\)$', title)
     if match is None:
         raise InvalidSectionTitle(title)
     version, date_str = match.groups()

--- a/src/catkin_pkg/package.py
+++ b/src/catkin_pkg/package.py
@@ -182,9 +182,9 @@ class Package(object):
 
         if not self.version:
             errors.append('Package version must not be empty')
-        elif not re.match('^[0-9]+\.[0-9]+\.[0-9]+$', self.version):
+        elif not re.match('^[0-9]+\.[0-9]+\.[0-9]+(-[0-9]+[a-z]+)?$', self.version):
             errors.append('Package version "%s" does not follow version conventions' % self.version)
-        elif not re.match('^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$', self.version):
+        elif not re.match('^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9]+[a-z]+)?$', self.version):
             new_warnings.append('Package "%s" does not follow the version conventions. It should not contain leading zeros (unless the number is 0).' % self.name)
 
         if not self.description:


### PR DESCRIPTION
The revision is appended to the upstream version by a vendor to indicate
that the package is altered from upstream packaging.

This allows for users to create packages using the proper upstream
version with their own patch-set applied on top.