### PR TITLE
[catkin_prepare_release] Fix wrong order of printed strings.

### DIFF
--- a/src/catkin_pkg/metapackage.py
+++ b/src/catkin_pkg/metapackage.py
@@ -151,7 +151,7 @@ Invalid CMakeLists.txt
 Expected:
 <<<%s>>>
 Got:
-<<<%s>>>""" % (get_cmakelists_txt(path), get_expected_cmakelists_txt(package.name)), path, package
+<<<%s>>>""" % (get_expected_cmakelists_txt(package.name), get_cmakelists_txt(path)), path, package
         )
     # Does it buildtool depend on catkin, else raise
     if not package.has_buildtool_depend_on_catkin():


### PR DESCRIPTION
As in [my old PR](https://github.com/ros-infrastructure/catkin_pkg/pull/118), line-break is expected at the end of `CMakeLists.txt` in meta packages. But the printed "Got" and "Expected" string portions are opposite ("Got" part has a line-break).

```
$ catkin_prepare_release
 
Prepare the source repository for a release.
Repository type: git
Found packages: moveit_controller_manager_example, moveit_ros_control_interface, moveit_fake_controller_manager, moveit_ros_perception, moveit_ros_move_group, moveit_ikfast, moveit_setup_assistant, moveit$
ros_robot_interaction, moveit_plugins, moveit_ros_benchmarks, moveit_ros_warehouse, moveit_commander, moveit_ros_visualization, moveit_ros_planning_interface, moveit_ros_benchmarks_gui, moveit_ros_plannin$
, moveit_core, moveit_planners, moveit_ros_manipulation, moveit_ros, moveit_simple_controller_manager, moveit_planners_ompl, moveit
Invalid metapackage at path '/home/rosnoodle/cws_planning/src/ros-planning/moveit/moveit':
  Metapackage 'moveit': Invalid CMakeLists.txt
Expected:
<<<cmake_minimum_required(VERSION 2.8.3)
project(moveit)
find_package(catkin REQUIRED)
catkin_metapackage()>>>
Got:
<<<cmake_minimum_required(VERSION 2.8.3)
project(moveit)
find_package(catkin REQUIRED)
catkin_metapackage()
>>>

See requirements for metapackages: http://ros.org/reps/rep-0127.html#metapackage

$ dpkg -p python-catkin-pkg|grep Ver
Version: 0.2.10-1
```

Related downstream issue https://github.com/ros-planning/moveit/issues/84