### PR TITLE
Install catkin_pkg.cli modules.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ from catkin_pkg import __version__
 setup(
     name='catkin_pkg',
     version=__version__,
-    packages=['catkin_pkg'],
+    packages=['catkin_pkg', 'catkin_pkg.cli'],
     package_dir={'': 'src'},
     package_data={'catkin_pkg': ['templates/*.in']},
     entry_points={


### PR DESCRIPTION
The new `catkin_pkg.cli` module was not installed by `setup.py`. This PR rectifies that.