### PR TITLE
Help ROS Users Switch to C++11

### DIFF
--- a/src/catkin_pkg/templates/CMakeLists.txt.in
+++ b/src/catkin_pkg/templates/CMakeLists.txt.in
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(@name)
 
+## Add support for C++11, supported in ROS Kinetic and newer
+# add_definitions(-std=c++11)
+
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages


### PR DESCRIPTION
Help users such as [these guys](https://github.com/ros-industrial/universal_robot/pull/254) use MoveIt! in Kinetic that requires C++11. Switching is of course optional.