### PR TITLE
Added --python-modules argument to catkin_create_pkg to automatically…

### DIFF
--- a/src/catkin_pkg/cli/create_pkg.py
+++ b/src/catkin_pkg/cli/create_pkg.py
@@ -43,6 +43,9 @@ def main(argv=sys.argv[1:], parent_path=os.getcwd()):
                         help='A single maintainer, may be used multiple times')
     rosdistro_name = os.environ['ROS_DISTRO'] if 'ROS_DISTRO' in os.environ else None
     parser.add_argument('--rosdistro', required=rosdistro_name is None, default=rosdistro_name, help='The ROS distro (default: environment variable ROS_DISTRO if defined)')
+    parser.add_argument('-p', '--python-modules',
+                        nargs='*',
+                        help='Python modules this package declares')
 
     args = parser.parse_args(argv)
 
@@ -63,7 +66,8 @@ def main(argv=sys.argv[1:], parent_path=os.getcwd()):
                              package_template=package_template,
                              rosdistro=args.rosdistro,
                              newfiles={},
-                             meta=args.meta)
+                             meta=args.meta,
+                             python_modules=args.python_modules)
         print('Successfully created files in %s. Please adjust the values in package.xml.' % target_path)
     except ValueError as vae:
         parser.error(str(vae))

--- a/src/catkin_pkg/package_templates.py
+++ b/src/catkin_pkg/package_templates.py
@@ -191,8 +191,17 @@ def _safe_write_files(newfiles, target_dir):
         print('Created file %s' % os.path.relpath(target_file, os.path.dirname(target_dir)))
 
 
+def _create_empty_file(path):
+    """
+    Creates an empty file on the disk.
+    :param path: The filename to be created.
+    """
+    with open(path, 'a'):
+        pass
+
+
 def create_package_files(target_path, package_template, rosdistro,
-                         newfiles=None, meta=False):
+                         newfiles=None, meta=False, python_modules=None):
     """
     creates several files from templates to start a new package.
 
@@ -203,6 +212,11 @@ def create_package_files(target_path, package_template, rosdistro,
     """
     if newfiles is None:
         newfiles = {}
+    # we distinguish between None and [] here: [] means to create a module
+    # with the same name as the package; None means "do not generate setup.py"
+    has_python_modules = python_modules is not None
+    if has_python_modules and len(python_modules) == 0:
+        python_modules = [package_template.name]
     # allow to replace default templates when path string is equal
     manifest_path = os.path.join(target_path, PACKAGE_MANIFEST_FILENAME)
     if manifest_path not in newfiles:
@@ -210,17 +224,31 @@ def create_package_files(target_path, package_template, rosdistro,
             create_package_xml(package_template, rosdistro, meta=meta)
     cmake_path = os.path.join(target_path, 'CMakeLists.txt')
     if not cmake_path in newfiles:
-        newfiles[cmake_path] = create_cmakelists(package_template, rosdistro, meta=meta)
+        newfiles[cmake_path] = create_cmakelists(package_template, rosdistro, meta=meta,
+                                                 has_python_modules=has_python_modules)
+    if has_python_modules:
+        setup_py_path = os.path.join(target_path, 'setup.py')
+        if not setup_py_path in newfiles:
+            newfiles[setup_py_path] = create_setup_py(package_template, rosdistro,
+                                                      python_modules=python_modules)
     _safe_write_files(newfiles, target_path)
     if 'roscpp' in package_template.catkin_deps:
         fname = os.path.join(target_path, 'include', package_template.name)
         os.makedirs(fname)
         print('Created folder %s' % os.path.relpath(fname, os.path.dirname(target_path)))
     if 'roscpp' in package_template.catkin_deps or \
-            'rospy' in package_template.catkin_deps:
+            'rospy' in package_template.catkin_deps or has_python_modules:
         fname = os.path.join(target_path, 'src')
         os.makedirs(fname)
         print('Created folder %s' % os.path.relpath(fname, os.path.dirname(target_path)))
+    if has_python_modules:
+        for module in python_modules:
+            fname = os.path.join(target_path, 'src', module)
+            os.makedirs(fname)
+            print('Created folder %s' % os.path.relpath(fname, os.path.dirname(target_path)))
+            fname = os.path.join(fname, '__init__.py')
+            _create_empty_file(fname)
+            print('Created file %s' % os.path.relpath(fname, os.path.dirname(target_path)))
 
 
 class CatkinTemplate(string.Template):
@@ -229,7 +257,7 @@ class CatkinTemplate(string.Template):
     escape = '@'
 
 
-def create_cmakelists(package_template, rosdistro, meta=False):
+def create_cmakelists(package_template, rosdistro, meta=False, has_python_modules=False):
     """
     :param package_template: contains the required information
     :returns: file contents as string
@@ -270,6 +298,9 @@ def create_cmakelists(package_template, rosdistro, meta=False):
             message_depends = '#   %s' % '#   '.join(message_pkgs)
         else:
             message_depends = '#   std_msgs  # Or other packages containing msgs'
+        catkin_python_setup = "catkin_python_setup()"
+        if not has_python_modules:
+            catkin_python_setup = "# " + catkin_python_setup
         temp_dict = {'name': package_template.name,
                      'components': components,
                      'include_directories': _create_include_macro(package_template),
@@ -278,7 +309,8 @@ def create_cmakelists(package_template, rosdistro, meta=False):
                      'catkin_depends': catkin_depends,
                      'system_depends': system_depends,
                      'target_libraries': _create_targetlib_args(package_template),
-                     'message_dependencies': message_depends
+                     'message_dependencies': message_depends,
+                     'catkin_python_setup': catkin_python_setup,
                      }
         return ctemp.substitute(temp_dict)
 
@@ -436,4 +468,21 @@ def create_package_xml(package_template, rosdistro, meta=False):
 
     temp_dict['components'] = package_template.catkin_deps
 
+    return ctemp.substitute(temp_dict)
+
+
+def create_setup_py(package_template, rosdistro, python_modules=None):
+    """
+    :param package_template: contains the required information
+    :returns: file contents as string
+    """
+    setup_py_template = read_template_file('setup.py', rosdistro)
+    ctemp = CatkinTemplate(setup_py_template)
+
+    python_modules = python_modules or []
+    modules = ", ".join(["'%s'" % module for module in python_modules])
+
+    temp_dict = {'name': package_template.name,
+                 'python_modules': modules
+                 }
     return ctemp.substitute(temp_dict)

--- a/src/catkin_pkg/templates/CMakeLists.txt.in
+++ b/src/catkin_pkg/templates/CMakeLists.txt.in
@@ -16,7 +16,7 @@ find_package(catkin REQUIRED@components)
 ## Uncomment this if the package has a setup.py. This macro ensures
 ## modules and global scripts declared therein get installed
 ## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
-# catkin_python_setup()
+@catkin_python_setup
 
 ################################################
 ## Declare ROS messages, services and actions ##

--- a/src/catkin_pkg/templates/setup.py.in
+++ b/src/catkin_pkg/templates/setup.py.in
@@ -1,0 +1,13 @@
+## ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
+
+from distutils.core import setup
+from catkin_pkg.python_setup import generate_distutils_setup
+
+# fetch values from package.xml
+setup_args = generate_distutils_setup(
+    packages=[@python_modules],
+
+    package_dir={'': 'src'},
+)
+
+setup(**setup_args)


### PR DESCRIPTION
… create the setup.py file.

I'm open for discussion about this PR - I don't tell I've chosen the only correct way to cope with that :)

I can't make my mind if it'd be good to augment the `Package` class with slot `python_modules` which would actually read the list of modules from `setup.py`. I'm not sure if it wouldn't be too big change (and maybe too useless :) ).