### PR TITLE
add conflict with debian package `catkin`

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,7 +1,7 @@
 [DEFAULT]
 Depends: python-argparse, python-dateutil, python-docutils
 Depends3: python3-dateutil, python3-docutils
-Conflicts: python3-catkin-pkg
-Conflicts3: python-catkin-pkg
+Conflicts: python3-catkin-pkg, catkin
+Conflicts3: python-catkin-pkg, catkin
 Suite: oneiric precise quantal raring saucy trusty utopic vivid wily xenial yakkety zesty wheezy jessie stretch
 X-Python3-Version: >= 3.2

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,7 +1,7 @@
 [DEFAULT]
 Depends: python-argparse, python-dateutil, python-docutils
 Depends3: python3-dateutil, python3-docutils
-Conflicts: python3-catkin-pkg, catkin
-Conflicts3: python-catkin-pkg, catkin
+Conflicts: catkin, python3-catkin-pkg
+Conflicts3: catkin, python-catkin-pkg
 Suite: oneiric precise quantal raring saucy trusty utopic vivid wily xenial yakkety zesty wheezy jessie stretch
 X-Python3-Version: >= 3.2


### PR DESCRIPTION
This is done to avoid the state where someone has our Python packages (the packages.ros.org `.deb` files) for `catkin_pkg` and/or `rospkg`, but are using the upstream "Debian Science" packages for ROS's C++ components (these are available from Ubuntu without any added apt sources). This situation leads to subtle bugs and should be avoided.

See:

- https://github.com/ros-infrastructure/rospkg/pull/102#issuecomment-273509972
- http://wiki.ros.org/UpstreamPackages