### PR TITLE
split into two Debian packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,44 +1,53 @@
 #!/usr/bin/env python
 
-from setuptools import setup
-
 import os
 import sys
+
+from setuptools import setup
+
 source = os.path.join(os.path.dirname(__file__), 'src')
 sys.path.insert(0, source)
 
-from catkin_pkg import __version__
+from catkin_pkg import __version__  # noqa
 
-setup(
-    name='catkin_pkg',
-    version=__version__,
-    packages=['catkin_pkg', 'catkin_pkg.cli'],
-    package_dir={'': 'src'},
-    package_data={'catkin_pkg': ['templates/*.in']},
-    entry_points={
-        'console_scripts' : [
+kwargs = {
+    'name': 'catkin_pkg',
+    'version': __version__,
+    'packages': ['catkin_pkg', 'catkin_pkg.cli'],
+    'package_dir': {'': 'src'},
+    'package_data': {'catkin_pkg': ['templates/*.in']},
+    'entry_points': {
+        'console_scripts': [
             'catkin_create_pkg = catkin_pkg.cli.create_pkg:main',
             'catkin_find_pkg = catkin_pkg.cli.find_pkg:main',
             'catkin_generate_changelog = catkin_pkg.cli.generate_changelog:main_catching_runtime_error',
             'catkin_tag_changelog = catkin_pkg.cli.tag_changelog:main',
             'catkin_test_changelog = catkin_pkg.cli.test_changelog:main',
-        ]
-    },
-    author='Dirk Thomas',
-    author_email='dthomas@osrfoundation.org',
-    url='http://wiki.ros.org/catkin_pkg',
-    download_url='http://download.ros.org/downloads/catkin_pkg/',
-    keywords=['catkin', 'ROS'],
-    classifiers=[
+        ]},
+    'author': 'Dirk Thomas',
+    'author_email': 'dthomas@osrfoundation.org',
+    'url': 'http://wiki.ros.org/catkin_pkg',
+    'download_url': 'http://download.ros.org/downloads/catkin_pkg/',
+    'keywords': ['catkin', 'ROS'],
+    'classifiers': [
         'Programming Language :: Python',
         'License :: OSI Approved :: BSD License'
     ],
-    description='catkin package library',
-    long_description='Library for retrieving information about catkin packages.',
-    license='BSD',
-    install_requires=[
+    'description': 'catkin package library',
+    'long_description': 'Library for retrieving information about catkin packages.',
+    'license': 'BSD',
+    'install_requires': [
         'argparse',
         'docutils',
         'python-dateutil'
     ],
-)
+}
+if 'SKIP_PYTHON_MODULES' in os.environ:
+    kwargs['packages'] = []
+    kwargs['package_dir'] = {}
+    kwargs['package_data'] = {}
+if 'SKIP_PYTHON_SCRIPTS' in os.environ:
+    kwargs['name'] += '_modules'
+    kwargs['entry_points'] = {}
+
+setup(**kwargs)

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,7 +1,18 @@
-[DEFAULT]
-Depends: python-argparse, python-dateutil, python-docutils
-Depends3: python3-dateutil, python3-docutils
+[catkin_pkg]
+Depends: python-argparse, python-catkin-pkg-modules, python-dateutil, python-docutils
+Depends3: python3-catkin-pkg-modules, python3-dateutil, python3-docutils
 Conflicts: catkin, python3-catkin-pkg
 Conflicts3: catkin, python-catkin-pkg
 Suite: oneiric precise quantal raring saucy trusty utopic vivid wily xenial yakkety zesty wheezy jessie stretch
 X-Python3-Version: >= 3.2
+Setup-Env-Vars: SKIP_PYTHON_MODULES=1
+
+[catkin_pkg_modules]
+Source: catkin_pkg_modules
+Depends: python-argparse, python-dateutil, python-docutils
+Depends3: python3-dateutil, python3-docutils
+Conflicts: catkin
+Conflicts3: catkin
+Suite: oneiric precise quantal raring saucy trusty utopic vivid wily xenial yakkety zesty wheezy jessie stretch
+X-Python3-Version: >= 3.2
+Setup-Env-Vars: SKIP_PYTHON_SCRIPTS=1


### PR DESCRIPTION
Alternative approach to achieve #125.

For PIP a single package is being generated as before. Two separate Debian packages are generated - one only containing the Python modules (`python(3)-catkin-pkg-modules`), one containing only the scripts (`python(3)-catkin-pkg`) which depends on the first one.

Requires ros-infrastructure/ros_release_python#15.

@ros-infrastructure/ros_team Please review and comment.