### PR TITLE
remove trailing whitespace

### DIFF
--- a/src/catkin_pkg/templates/package.xml.in
+++ b/src/catkin_pkg/templates/package.xml.in
@@ -4,7 +4,7 @@
   <version@version_abi>@version</version>
   <description>@description</description>
 
-  <!-- One maintainer tag required, multiple allowed, one person per tag --> 
+  <!-- One maintainer tag required, multiple allowed, one person per tag -->
   <!-- Example:  -->
   <!-- <maintainer email="jane.doe@@example.com">Jane Doe</maintainer> -->
 @maintainers


### PR DESCRIPTION
This PR cleanes up a trainling whitespace in the package.xml template, as it shows up during code review of generated package.xml files.
