### PR TITLE
Allow dashes in package names for non-catkin packages.

### DIFF
--- a/src/catkin_pkg/package.py
+++ b/src/catkin_pkg/package.py
@@ -177,8 +177,17 @@ class Package(object):
         # accepting upper case letters and hyphens only for backward compatibility
         if not re.match('^[a-zA-Z0-9][a-zA-Z0-9_-]*$', self.name):
             errors.append('Package name "%s" does not follow naming conventions' % self.name)
-        elif not re.match('^[a-z][a-z0-9_]*$', self.name):
-            new_warnings.append('Package name "%s" does not follow the naming conventions. It should start with a lower case letter and only contain lower case letters, digits and underscores.' % self.name)
+        else:
+            if self.has_buildtool_depend_on_catkin():
+                if not re.match('^[a-z][a-z0-9_]*$', self.name):
+                    new_warnings.append(
+                            'Catkin package name "%s" does not follow the naming conventions. It should start with '
+                            'a lower case letter and only contain lower case letters, digits and underscores.' % self.name)
+            else:
+                if not re.match('^[a-z][a-z0-9_-]*$', self.name):
+                    new_warnings.append(
+                            'Non-catkin package name "%s" does not follow the naming conventions. It should start with'
+                            'a lower case letter and only contain lower case letters, digits, underscores, and dashes.' % self.name)
 
         if not self.version:
             errors.append('Package version must not be empty')

--- a/src/catkin_pkg/package.py
+++ b/src/catkin_pkg/package.py
@@ -137,6 +137,18 @@ class Package(object):
         """
         return 'catkin' in [d.name for d in self.buildtool_depends]
 
+    def build_type(self):
+        """
+        Returns value of export/build_type element, or 'catkin' if unspecified.
+
+        :returns: package build type
+        :rtype: str
+        """
+        for e in self.exports:
+            if e.tagname == 'build_type':
+                return e.content
+        return 'catkin'
+
     def has_invalid_metapackage_dependencies(self):
         """
         Returns True if this package has invalid dependencies for a metapackage
@@ -178,7 +190,7 @@ class Package(object):
         if not re.match('^[a-zA-Z0-9][a-zA-Z0-9_-]*$', self.name):
             errors.append('Package name "%s" does not follow naming conventions' % self.name)
         else:
-            if self.has_buildtool_depend_on_catkin():
+            if self.build_type() == 'catkin':
                 if not re.match('^[a-z][a-z0-9_]*$', self.name):
                     new_warnings.append(
                             'Catkin package name "%s" does not follow the naming conventions. It should start with '

--- a/src/catkin_pkg/package.py
+++ b/src/catkin_pkg/package.py
@@ -196,13 +196,13 @@ class Package(object):
             if self.get_build_type() == 'catkin':
                 if not re.match('^[a-z][a-z0-9_]*$', self.name):
                     new_warnings.append(
-                            'Catkin package name "%s" does not follow the naming conventions. It should start with '
-                            'a lower case letter and only contain lower case letters, digits, and underscores.' % self.name)
+                        'Catkin package name "%s" does not follow the naming conventions. It should start with '
+                        'a lower case letter and only contain lower case letters, digits, and underscores.' % self.name)
             else:
                 if not re.match('^[a-z][a-z0-9_-]*$', self.name):
                     new_warnings.append(
-                            'Non-catkin package name "%s" does not follow the naming conventions. It should start with'
-                            'a lower case letter and only contain lower case letters, digits, underscores, and dashes.' % self.name)
+                        'Non-catkin package name "%s" does not follow the naming conventions. It should start with'
+                        'a lower case letter and only contain lower case letters, digits, underscores, and dashes.' % self.name)
 
         if not self.version:
             errors.append('Package version must not be empty')

--- a/src/catkin_pkg/package.py
+++ b/src/catkin_pkg/package.py
@@ -137,17 +137,21 @@ class Package(object):
         """
         return 'catkin' in [d.name for d in self.buildtool_depends]
 
-    def build_type(self):
+    def get_build_type(self):
         """
         Returns value of export/build_type element, or 'catkin' if unspecified.
 
         :returns: package build type
         :rtype: str
+        :raises: :exc:`InvalidPackage`
         """
-        for e in self.exports:
-            if e.tagname == 'build_type':
-                return e.content
-        return 'catkin'
+        build_type_exports = [e.content for e in self.exports if e.tagname == 'build_type']
+        if not build_type_exports:
+            return 'catkin'
+        elif len(build_type_exports) == 1:
+            return build_type_exports[0]
+        else:
+            raise InvalidPackage('Only one <build_type> element is permitted.')
 
     def has_invalid_metapackage_dependencies(self):
         """
@@ -190,7 +194,7 @@ class Package(object):
         if not re.match('^[a-zA-Z0-9][a-zA-Z0-9_-]*$', self.name):
             errors.append('Package name "%s" does not follow naming conventions' % self.name)
         else:
-            if self.build_type() == 'catkin':
+            if self.get_build_type() == 'catkin':
                 if not re.match('^[a-z][a-z0-9_]*$', self.name):
                     new_warnings.append(
                             'Catkin package name "%s" does not follow the naming conventions. It should start with '

--- a/src/catkin_pkg/package.py
+++ b/src/catkin_pkg/package.py
@@ -139,7 +139,7 @@ class Package(object):
 
     def get_build_type(self):
         """
-        Returns value of export/build_type element, or 'catkin' if unspecified.
+        Return value of export/build_type element, or 'catkin' if unspecified.
 
         :returns: package build type
         :rtype: str
@@ -148,10 +148,9 @@ class Package(object):
         build_type_exports = [e.content for e in self.exports if e.tagname == 'build_type']
         if not build_type_exports:
             return 'catkin'
-        elif len(build_type_exports) == 1:
+        if len(build_type_exports) == 1:
             return build_type_exports[0]
-        else:
-            raise InvalidPackage('Only one <build_type> element is permitted.')
+        raise InvalidPackage('Only one <build_type> element is permitted.')
 
     def has_invalid_metapackage_dependencies(self):
         """
@@ -198,7 +197,7 @@ class Package(object):
                 if not re.match('^[a-z][a-z0-9_]*$', self.name):
                     new_warnings.append(
                             'Catkin package name "%s" does not follow the naming conventions. It should start with '
-                            'a lower case letter and only contain lower case letters, digits and underscores.' % self.name)
+                            'a lower case letter and only contain lower case letters, digits, and underscores.' % self.name)
             else:
                 if not re.match('^[a-z][a-z0-9_-]*$', self.name):
                     new_warnings.append(

--- a/test/test_package.py
+++ b/test/test_package.py
@@ -4,7 +4,7 @@ import unittest
 import sys
 sys.stderr = sys.stdout
 
-from catkin_pkg.package import Dependency, InvalidPackage, Package, Person
+from catkin_pkg.package import Dependency, Export, InvalidPackage, Package, Person
 
 from mock import Mock
 
@@ -143,8 +143,7 @@ class PackageTest(unittest.TestCase):
                        version_abi='pabi',
                        description='pdesc',
                        licenses=['BSD'],
-                       maintainers=[maint],
-                       buildtool_depends=[Dependency('catkin')])
+                       maintainers=[maint])
         pack.validate()
 
         # names that should error
@@ -170,11 +169,12 @@ class PackageTest(unittest.TestCase):
         self.assertIn('naming conventions', warnings[0])
 
         # dashes are permitted for a non-catkin package
-        pack.buildtool_depends[0].name = 'other'
+        pack.exports.append(Export('build_type', 'other'))
         pack.name = 'bar-bza'
         warnings = []
         pack.validate(warnings=warnings)
         self.assertEquals(warnings, [])
+        pack.exports.pop()
 
         # check authors emails
         pack.name = 'bar'


### PR DESCRIPTION
Rationale given in #161.