### PR TITLE
Check python version in a 2.6 and below compatible manner.

### DIFF
--- a/src/catkin_pkg/changelog.py
+++ b/src/catkin_pkg/changelog.py
@@ -43,7 +43,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import sys
-_py3 = sys.version_info >= (3, 0)
+_py3 = sys.version_info[0] >= 3
 
 import dateutil.parser
 import docutils

--- a/src/catkin_pkg/package.py
+++ b/src/catkin_pkg/package.py
@@ -371,7 +371,7 @@ def parse_package(path, warnings=None):
     # Force utf8 encoding for python3.
     # This way unicode files can still be processed on non-unicode locales.
     kwargs = {}
-    if sys.version_info.major >= 3:
+    if sys.version_info[0] >= 3:
         kwargs['encoding'] = 'utf8'
 
     with open(filename, 'r', **kwargs) as f:


### PR DESCRIPTION
Changed the way python2/3 is detected. Now uses the same check as `changelog.py` [1].

This should be compatible with python versions below 2.7, which the old check was not (see also [2]). 

[1] https://github.com/ros-infrastructure/catkin_pkg/blob/fe86f9277eef68a0ebe0c16047e795f3b1533f54/src/catkin_pkg/changelog.py#L46
[2] https://github.com/ros-infrastructure/catkin_pkg/commit/84b14a0668a9728525d2bfe7eb33abd915e555e5#commitcomment-21710999