### PR TITLE
updating template to populate include_directories() with #

### DIFF
--- a/src/catkin_pkg/package_templates.py
+++ b/src/catkin_pkg/package_templates.py
@@ -294,10 +294,12 @@ def _create_targetlib_args(package_template):
 
 
 def _create_include_macro(package_template):
-    result = '# include_directories(include)'
+    result = '#  include'
     includes = []
     if package_template.catkin_deps:
         includes.append('${catkin_INCLUDE_DIRS}')
+    else:
+        includes.append('#  ${catkin_INCLUDE_DIRS}')
     if package_template.boost_comps:
         includes.append('${Boost_INCLUDE_DIRS}')
     if package_template.system_deps:
@@ -309,7 +311,7 @@ def _create_include_macro(package_template):
         if deplist:
             result += '\n# TODO: Check names of system library include directories (%s)' % ', '.join(deplist)
     if includes:
-        result += '\ninclude_directories(\n  %s\n)' % '\n  '.join(includes)
+        result += '\n%s' % '\n  '.join(includes)
     return result
 
 

--- a/src/catkin_pkg/package_templates.py
+++ b/src/catkin_pkg/package_templates.py
@@ -294,7 +294,6 @@ def _create_targetlib_args(package_template):
 
 
 def _create_include_macro(package_template):
-    result = ''
     includes = ['# include']
     includes.append(('  ' if package_template.catkin_deps else '# ') + '${catkin_INCLUDE_DIRS}')
     if package_template.boost_comps:
@@ -308,6 +307,7 @@ def _create_include_macro(package_template):
             todo_incl = '# TODO: Check names of system library include directories'
             includes.append(todo_incl + (' (%s)' % ', '.join(deplist)))
             includes.extend(['  ${%s_INCLUDE_DIRS}' % sysdep for sysdep in deplist])
+    result = ''
     if includes:
         result += '%s' % '\n'.join(includes)
     return result

--- a/src/catkin_pkg/package_templates.py
+++ b/src/catkin_pkg/package_templates.py
@@ -309,7 +309,7 @@ def _create_include_macro(package_template):
             includes.extend(['  ${%s_INCLUDE_DIRS}' % sysdep for sysdep in deplist])
     result = ''
     if includes:
-        result += '%s' % '\n'.join(includes)
+        result += '\n'.join(includes)
     return result
 
 def _create_depend_tag(dep_type,

--- a/src/catkin_pkg/package_templates.py
+++ b/src/catkin_pkg/package_templates.py
@@ -294,26 +294,22 @@ def _create_targetlib_args(package_template):
 
 
 def _create_include_macro(package_template):
-    result = '#  include'
-    includes = []
-    if package_template.catkin_deps:
-        includes.append('${catkin_INCLUDE_DIRS}')
-    else:
-        includes.append('#  ${catkin_INCLUDE_DIRS}')
+    result = ''
+    includes = ['# include']
+    includes.append(('  ' if package_template.catkin_deps else '# ') + '${catkin_INCLUDE_DIRS}')
     if package_template.boost_comps:
-        includes.append('${Boost_INCLUDE_DIRS}')
+        includes.append('  ${Boost_INCLUDE_DIRS}')
     if package_template.system_deps:
         deplist = []
         for sysdep in package_template.system_deps:
             if not sysdep.startswith('python-'):
                 deplist.append(sysdep)
-                includes.append('${%s_INCLUDE_DIRS}' % sysdep)
         if deplist:
-            result += '\n# TODO: Check names of system library include directories (%s)' % ', '.join(deplist)
+            includes.append('# TODO: Check names of system library include directories (%s)' % ', '.join(deplist))
+            includes.extend(['  ${%s_INCLUDE_DIRS}' % sysdep for sysdep in deplist])
     if includes:
-        result += '\n%s' % '\n  '.join(includes)
+        result += '%s' % '\n'.join(includes)
     return result
-
 
 def _create_depend_tag(dep_type,
                        name,

--- a/src/catkin_pkg/package_templates.py
+++ b/src/catkin_pkg/package_templates.py
@@ -305,7 +305,8 @@ def _create_include_macro(package_template):
             if not sysdep.startswith('python-'):
                 deplist.append(sysdep)
         if deplist:
-            includes.append('# TODO: Check names of system library include directories (%s)' % ', '.join(deplist))
+            todo_incl = '# TODO: Check names of system library include directories'
+            includes.append(todo_incl + (' (%s)' % ', '.join(deplist)))
             includes.extend(['  ${%s_INCLUDE_DIRS}' % sysdep for sysdep in deplist])
     if includes:
         result += '%s' % '\n'.join(includes)

--- a/src/catkin_pkg/templates/CMakeLists.txt.in
+++ b/src/catkin_pkg/templates/CMakeLists.txt.in
@@ -111,7 +111,9 @@ catkin_package(
 
 ## Specify additional locations of header files
 ## Your package locations should be listed before other locations
+include_directories(
 @include_directories
+)
 
 ## Declare a C++ library
 # add_library(${PROJECT_NAME}

--- a/test/test_templates.py
+++ b/test/test_templates.py
@@ -105,27 +105,27 @@ class TemplateTest(unittest.TestCase):
         mock_pack.boost_comps = []
         mock_pack.system_deps = []
         statement = _create_include_macro(mock_pack)
-        self.assertEqual('# include_directories(include)', statement)
+        self.assertEqual('# include\n# ${catkin_INCLUDE_DIRS}', statement)
         mock_pack.catkin_deps = ['roscpp', 'rospy']
         mock_pack.boost_comps = []
         mock_pack.system_deps = []
         statement = _create_include_macro(mock_pack)
-        self.assertEqual('# include_directories(include)\ninclude_directories(\n  ${catkin_INCLUDE_DIRS}\n)', statement)
+        self.assertEqual('# include\n  ${catkin_INCLUDE_DIRS}', statement)
         mock_pack.catkin_deps = ['roscpp']
         mock_pack.boost_comps = ['thread', 'filesystem']
         mock_pack.system_deps = []
         statement = _create_include_macro(mock_pack)
-        self.assertEqual('# include_directories(include)\ninclude_directories(\n  ${catkin_INCLUDE_DIRS}\n  ${Boost_INCLUDE_DIRS}\n)', statement)
+        self.assertEqual('# include\n  ${catkin_INCLUDE_DIRS}\n  ${Boost_INCLUDE_DIRS}', statement)
         mock_pack.catkin_deps = ['roscpp']
         mock_pack.boost_comps = []
         mock_pack.system_deps = ['log4cxx', 'BZip2']
         statement = _create_include_macro(mock_pack)
-        self.assertEqual('# include_directories(include)\n# TODO: Check names of system library include directories (log4cxx, BZip2)\ninclude_directories(\n  ${catkin_INCLUDE_DIRS}\n  ${log4cxx_INCLUDE_DIRS}\n  ${BZip2_INCLUDE_DIRS}\n)', statement)
+        self.assertEqual('# include\n  ${catkin_INCLUDE_DIRS}\n# TODO: Check names of system library include directories (log4cxx, BZip2)\n  ${log4cxx_INCLUDE_DIRS}\n  ${BZip2_INCLUDE_DIRS}', statement)
         mock_pack.catkin_deps = ['roscpp']
         mock_pack.boost_comps = ['thread', 'filesystem']
         mock_pack.system_deps = ['log4cxx', 'BZip2']
         statement = _create_include_macro(mock_pack)
-        self.assertEqual('# include_directories(include)\n# TODO: Check names of system library include directories (log4cxx, BZip2)\ninclude_directories(\n  ${catkin_INCLUDE_DIRS}\n  ${Boost_INCLUDE_DIRS}\n  ${log4cxx_INCLUDE_DIRS}\n  ${BZip2_INCLUDE_DIRS}\n)', statement)
+        self.assertEqual('# include\n  ${catkin_INCLUDE_DIRS}\n  ${Boost_INCLUDE_DIRS}\n# TODO: Check names of system library include directories (log4cxx, BZip2)\n  ${log4cxx_INCLUDE_DIRS}\n  ${BZip2_INCLUDE_DIRS}', statement)
 
     def test_create_package(self):
         maint = self.get_maintainer()


### PR DESCRIPTION
This takes a stab at #167 . I thought of two routes and ended up modeling this after the behavior for `catkin_package()` in the template; providing no dependencies to `catkin_create_pkg` will yield this:

```
## Specify additional locations of header files
## Your package locations should be listed before other locations
include_directories(
#  include
#  ${catkin_INCLUDE_DIRS}
)
```
So, you get an empty call this way.

---

Alternatively, the current behavior is to initialize `result` with this:
```
# include_directories(include)
```
Any actual includes are wrapped in `include_directories()` and appended *if* they exist. So, my second route would have been:
```
def _create_include_macro(package_template):
    result = '# include_directories(include)'
    includes = []
    if package_template.catkin_deps:
        includes.append('${catkin_INCLUDE_DIRS}')
    else:
        includes.append('#  ${catkin_INCLUDE_DIRS}')
...
```
I thought the first was cleaner, but the latter is more true to the original code.