### PR TITLE
multiprocessing improvements

### DIFF
--- a/src/catkin_pkg/packages.py
+++ b/src/catkin_pkg/packages.py
@@ -130,6 +130,14 @@ def find_packages_allowing_duplicates(basepath, exclude_paths=None, exclude_subs
     if not data:
         return {}
 
+    if len(data) < 100:
+        parsed_packages = {}
+        for xml, path, filename in data:
+            parsed_package = parse_package_string(
+                xml, filename=filename, warnings=warnings)
+            parsed_packages[path] = parsed_package
+        return parsed_packages
+
     parser = _PackageParser(warnings is not None)
     pool = multiprocessing.Pool()
     try:

--- a/src/catkin_pkg/packages.py
+++ b/src/catkin_pkg/packages.py
@@ -131,7 +131,12 @@ def find_packages_allowing_duplicates(basepath, exclude_paths=None, exclude_subs
         return {}
 
     parser = _PackageParser(warnings is not None)
-    path_parsed_packages, warnings_lists = zip(*multiprocessing.Pool().map(parser, data))
+    pool = multiprocessing.Pool()
+    try:
+        path_parsed_packages, warnings_lists = zip(*pool.map(parser, data))
+    finally:
+        pool.close()
+        pool.join()
     if parser.capture_warnings:
         map(warnings.extend, warnings_lists)
     return dict(path_parsed_packages)


### PR DESCRIPTION
The first commit fixes the problem reported in #175 that when hitting Ctrl-C each multiprocessing worker shows a `KeyboardInterrupt` exception.

The second commit fixes the performance regression of #171 since the startup of the multiprocessing workers dominates the runtime when the number of packages to parse is low. In the reported example roslaunch calls the function numerous time for a single package.

@mikepurvis FYI