### PR TITLE
catkin_generate_changelog: Fix UnicodeDecodeError

### DIFF
--- a/src/catkin_pkg/changelog_generator_vcs.py
+++ b/src/catkin_pkg/changelog_generator_vcs.py
@@ -97,7 +97,7 @@ class VcsClientBase(object):
         try:
             proc = subprocess.Popen(cmd, cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env=env)
             output, _ = proc.communicate()
-            result['output'] = output.rstrip().decode()
+            result['output'] = output.rstrip()
             result['returncode'] = proc.returncode
         except subprocess.CalledProcessError as e:
             result['output'] = e.output


### PR DESCRIPTION
IMO, this bug is relatively **urgent**, since a version containing this bug (0.3.4) was released today. This means that catkin_generate_changelog will crash for everyone when there's a non-ascii character in the git history since the last tag.

This bug was introduced in 9da8993. When a git commit's author contains an UTF8 character, such as "ü" (0xc3bc), the following error was produced:

```
Found packages: foo
Querying all tags and commit information...
Traceback (most recent call last):
  File "/usr/local/bin/catkin_generate_changelog", line 9, in <module>
    load_entry_point('catkin-pkg==0.3.4', 'console_scripts', 'catkin_generate_changelog')()
  File "/usr/local/lib/python2.7/dist-packages/catkin_pkg-0.3.4-py2.7.egg/catkin_pkg/cli/generate_changelog.py", line 120, in main_catching_runtime_error
    main(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/catkin_pkg-0.3.4-py2.7.egg/catkin_pkg/cli/generate_changelog.py", line 99, in main
    tag2log_entries = get_all_changes(vcs_client, skip_merges=args.skip_merges)
  File "/usr/local/lib/python2.7/dist-packages/catkin_pkg-0.3.4-py2.7.egg/catkin_pkg/changelog_generator.py", line 63, in get_all_changes
    from_tag=previous_tag.name, to_tag=None, skip_merges=skip_merges)
  File "/usr/local/lib/python2.7/dist-packages/catkin_pkg-0.3.4-py2.7.egg/catkin_pkg/changelog_generator_vcs.py", line 208, in get_log_entries
    log_entries.append(LogEntry(msg, affected_paths, self._get_author(hash_)))
  File "/usr/local/lib/python2.7/dist-packages/catkin_pkg-0.3.4-py2.7.egg/catkin_pkg/changelog_generator_vcs.py", line 143, in _get_author
    result = self._run_command(cmd)
  File "/usr/local/lib/python2.7/dist-packages/catkin_pkg-0.3.4-py2.7.egg/catkin_pkg/changelog_generator_vcs.py", line 100, in _run_command
    result['output'] = output.rstrip().decode()
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 4: ordinal not in range(128)
```

This PR fixes that.

How to reproduce:

    catkin_create_pkg foo
    cd foo
    git init
    git config user.email user@example.com
    git config user.name "mr. ütf8"   # this line triggers the bug
    git add :/
    git commit -m "Initial commit"
    catkin_generate_changelog --all

Tested on ROS Indigo + Ubuntu Trusty + Python 2.7 .