### PR TITLE
Fix encode/decode problems + raw_input

### DIFF
--- a/src/catkin_pkg/changelog_generator.py
+++ b/src/catkin_pkg/changelog_generator.py
@@ -108,8 +108,8 @@ def generate_changelogs(base_path, packages, tag2log_entries, logger=None, vcs_c
             logger.debug("- creating '%s'" % os.path.join(pkg_path, CHANGELOG_FILENAME))
         pkg_tag2log_entries = filter_package_changes(tag2log_entries, pkg_path)
         data = generate_changelog_file(package.name, pkg_tag2log_entries, vcs_client=vcs_client, skip_contributors=skip_contributors)
-        with open(changelog_path, 'w') as f:
-            f.write(data)
+        with open(changelog_path, 'wb') as f:
+            f.write(data.encode('utf-8'))
 
 
 def update_changelogs(base_path, packages, tag2log_entries, logger=None, vcs_client=None, skip_contributors=False):
@@ -119,11 +119,11 @@ def update_changelogs(base_path, packages, tag2log_entries, logger=None, vcs_cli
             logger.debug("- updating '%s'" % os.path.join(pkg_path, CHANGELOG_FILENAME))
         pkg_tag2log_entries = filter_package_changes(tag2log_entries, pkg_path)
         changelog_path = os.path.join(base_path, pkg_path, CHANGELOG_FILENAME)
-        with open(changelog_path, 'r') as f:
-            data = f.read()
+        with open(changelog_path, 'rb') as f:
+            data = f.read().decode('utf-8')
         data = update_changelog_file(data, pkg_tag2log_entries, vcs_client=vcs_client, skip_contributors=skip_contributors)
-        with open(changelog_path, 'w') as f:
-            f.write(data)
+        with open(changelog_path, 'wb') as f:
+            f.write(data.encode('utf-8'))
 
 
 def filter_package_changes(tag2log_entries, pkg_path):

--- a/src/catkin_pkg/changelog_generator_vcs.py
+++ b/src/catkin_pkg/changelog_generator_vcs.py
@@ -97,7 +97,7 @@ class VcsClientBase(object):
         try:
             proc = subprocess.Popen(cmd, cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env=env)
             output, _ = proc.communicate()
-            result['output'] = output.rstrip().decode()
+            result['output'] = output.rstrip().decode('utf-8')
             result['returncode'] = proc.returncode
         except subprocess.CalledProcessError as e:
             result['output'] = e.output

--- a/src/catkin_pkg/cli/generate_changelog.py
+++ b/src/catkin_pkg/cli/generate_changelog.py
@@ -6,6 +6,7 @@ import argparse
 import logging
 import os
 import sys
+from builtins import input
 
 from catkin_pkg.changelog import CHANGELOG_FILENAME
 from catkin_pkg.changelog_generator import generate_changelog_file, generate_changelogs, get_all_changes, get_forthcoming_changes, update_changelogs
@@ -21,7 +22,7 @@ def prompt_continue(msg, default):
         msg += ' [y/N]?'
 
     while True:
-        response = raw_input(msg)
+        response = input(msg)
         if not response:
             response = 'y' if default else 'n'
         else:

--- a/src/catkin_pkg/cli/tag_changelog.py
+++ b/src/catkin_pkg/cli/tag_changelog.py
@@ -109,5 +109,5 @@ def main(sysargs=None):
 
     print('Writing updated changelog files...')
     for (changelog_path, data) in new_changelog_data:
-        with open(changelog_path, 'w') as f:
-            f.write(data)
+        with open(changelog_path, 'wb') as f:
+            f.write(data.encode('utf-8'))


### PR DESCRIPTION
Replaces and fixes #178.

Tested on:

* Python 2.7.6
* Python 3.4.3

Without my second commit, the following exception was thrown in python3:


```
Traceback (most recent call last):
  File "/tmp/virt_env/p3/bin/catkin_generate_changelog", line 9, in <module>
    load_entry_point('catkin-pkg==0.3.4', 'console_scripts', 'catkin_generate_changelog')()
  File "/tmp/virt_env/p3/lib/python3.4/site-packages/catkin_pkg-0.3.4-py3.4.egg/catkin_pkg/cli/generate_changelog.py", line 120, in main_catching_runtime_error
    main(*args, **kwargs)
  File "/tmp/virt_env/p3/lib/python3.4/site-packages/catkin_pkg-0.3.4-py3.4.egg/catkin_pkg/cli/generate_changelog.py", line 94, in main
    if not args.non_interactive and not prompt_continue('Continue without --all option', default=False):
  File "/tmp/virt_env/p3/lib/python3.4/site-packages/catkin_pkg-0.3.4-py3.4.egg/catkin_pkg/cli/generate_changelog.py", line 24, in prompt_continue
    response = raw_input(msg)
NameError: name 'raw_input' is not defined
```

### How to test

```
# install catkin_pkg in Python3
mkdir virt_env
virtualenv virt_env/p3 -p python3   # leave out the `-p python3` to test under python2
source virt_env/p3/bin/activate
cd virt_env/p3/
git clone https://github.com/mintar/catkin_pkg.git -b fix_encode_decode_error2
cd catkin_pkg/
python setup.py install

# test it
cd ..
catkin_create_pkg foo
cd foo
git init
git config user.email user@example.com   # don't be afraid: this won't modify your global ~/.gitconfig, only foo/.git/config
git config user.name "mr. ütf8"   # this line triggers the bug
git add :/
git commit -m "Initial commit"
catkin_generate_changelog --all
```

If this last command doesn't throw a UnicodeDecodeError, the bug is fixed.