### PR TITLE
Added dashes to catkin packages naming

### DIFF
--- a/src/catkin_pkg/package.py
+++ b/src/catkin_pkg/package.py
@@ -194,10 +194,10 @@ class Package(object):
             errors.append('Package name "%s" does not follow naming conventions' % self.name)
         else:
             if self.get_build_type() == 'catkin':
-                if not re.match('^[a-z][a-z0-9_]*$', self.name):
+                if not re.match('^[a-z][a-z0-9_-]*$', self.name):
                     new_warnings.append(
                         'Catkin package name "%s" does not follow the naming conventions. It should start with '
-                        'a lower case letter and only contain lower case letters, digits, and underscores.' % self.name)
+                        'a lower case letter and only contain lower case letters, digits, underscores, and dashes.' % self.name)
             else:
                 if not re.match('^[a-z][a-z0-9_-]*$', self.name):
                     new_warnings.append(

--- a/test/test_package.py
+++ b/test/test_package.py
@@ -158,11 +158,6 @@ class PackageTest(unittest.TestCase):
         pack.validate(warnings=warnings)
         self.assertIn('naming conventions', warnings[0])
 
-        pack.name = 'bar-bza'
-        warnings = []
-        pack.validate(warnings=warnings)
-        self.assertIn('naming conventions', warnings[0])
-
         pack.name = 'BAR'
         warnings = []
         pack.validate(warnings=warnings)


### PR DESCRIPTION
[Rep 127](http://www.ros.org/reps/rep-0127.html#name) seems to allow dashes,
On my [last released package](https://github.com/ros/rosdistro/pull/15095), following @dirk-thomas guidance, the naming has been modified from python_watchdog to python-watchdog.

Now I'm getting plenty of warnings because of the name used when I run of build code.

@mikepurvis Why did you make a special case for catkin packages on https://github.com/ros-infrastructure/catkin_pkg/pull/162.

Maybe I'm missing something, please highlight me :)