### PR TITLE
fix handling of hidden folders

### DIFF
--- a/src/catkin_pkg/packages.py
+++ b/src/catkin_pkg/packages.py
@@ -66,7 +66,8 @@ def find_package_paths(basepath, exclude_paths=None, exclude_subspaces=False):
             paths.append(os.path.relpath(dirpath, basepath))
             del dirnames[:]
             continue
-        dirnames[:] = [d for d in dirnames if not d.startswith('.')] # filter out hidden directories in-place
+        # filter out hidden directories in-place
+        dirnames[:] = [d for d in dirnames if not d.startswith('.')]
     return paths
 
 

--- a/src/catkin_pkg/packages.py
+++ b/src/catkin_pkg/packages.py
@@ -66,9 +66,7 @@ def find_package_paths(basepath, exclude_paths=None, exclude_subspaces=False):
             paths.append(os.path.relpath(dirpath, basepath))
             del dirnames[:]
             continue
-        for dirname in dirnames:
-            if dirname.startswith('.'):
-                dirnames.remove(dirname)
+        dirnames[:] = [d for d in dirnames if not d.startswith('.')] # filter out hidden directories in-place
     return paths
 
 

--- a/test/test_packages.py
+++ b/test/test_packages.py
@@ -1,7 +1,10 @@
-from catkin_pkg.packages import find_package_paths, find_packages_allowing_duplicates
+import os
+
+from catkin_pkg.packages import find_package_paths
+from catkin_pkg.packages import find_packages_allowing_duplicates
 
 from .util import in_temporary_directory
-import os
+
 
 def _create_pkg_in_dir(path):
     os.mkdir(path)

--- a/test/test_packages.py
+++ b/test/test_packages.py
@@ -1,7 +1,21 @@
-from catkin_pkg.packages import find_packages_allowing_duplicates
+from catkin_pkg.packages import find_package_paths, find_packages_allowing_duplicates
 
 from .util import in_temporary_directory
+import os
 
+def _create_pkg_in_dir(path):
+    os.mkdir(path)
+    open(os.path.join(path, 'package.xml'), 'a').close()
+
+@in_temporary_directory
+def test_package_paths_with_hidden_directories():
+    _create_pkg_in_dir('.test1');
+    _create_pkg_in_dir('.test2');
+    _create_pkg_in_dir('test3'); # not hidden
+    _create_pkg_in_dir('.test4');
+
+    res = find_package_paths('.')
+    assert res == ['test3']
 
 @in_temporary_directory
 def test_find_packages_allowing_duplicates_with_no_packages():


### PR DESCRIPTION
The old code modified the `dirnames` list while iterating over it, which results in skipping some entries and sporadically hidden folders get returned.

Alternative implementation:
```python
for dirname in dirnames[:]:
    if dirname.startswith('.'):
        dirnames.remove(dirname)
```