### PR TITLE
 "--skip-merge"  does not change any outputs

### DIFF
--- a/src/catkin_pkg/changelog_generator_vcs.py
+++ b/src/catkin_pkg/changelog_generator_vcs.py
@@ -200,7 +200,7 @@ class GitClient(VcsClientBase):
                     continue
                 msg = result['output']
                 # query affected paths
-                cmd = [self._executable, 'show', hash_, '--name-only', '--format=format:""']
+                cmd = [self._executable, 'show', '-m', hash_, '--name-only', '--format=format:""']
                 result = self._run_command(cmd)
                 if result['returncode']:
                     raise RuntimeError('Could not fetch affected paths:\n%s' % result['output'])

--- a/src/catkin_pkg/changelog_generator_vcs.py
+++ b/src/catkin_pkg/changelog_generator_vcs.py
@@ -200,7 +200,7 @@ class GitClient(VcsClientBase):
                     continue
                 msg = result['output']
                 # query affected paths
-                cmd = [self._executable, 'show', '-m', hash_, '--name-only', '--format=format:""']
+                cmd = [self._executable, 'show', '--first-parent', hash_, '--name-only', '--format=format:""']
                 result = self._run_command(cmd)
                 if result['returncode']:
                     raise RuntimeError('Could not fetch affected paths:\n%s' % result['output'])


### PR DESCRIPTION
`catkin_generate_changelog`  outputs changelog with what we called with `--skip-merge` option, and reason is that `git show` does not show files for merged commit, we need '-m' option

```
k-okada@p40-yoga:/tmp/jsk_3rdparty$ git show 6a0bfaaf29bcc9a8e07e6edfccd230ad7f003070 --name-only --format=format:""

k-okada@p40-yoga:/tmp/jsk_3rdparty$ git show 6a0bfaaf29bcc9a8e07e6edfccd230ad7f003070
commit 6a0bfaaf29bcc9a8e07e6edfccd230ad7f003070
Merge: 5f6888c 54ea9bd
Author: Kei Okada <k-okada@jsk.t.u-tokyo.ac.jp>
Date:   Fri Jul 7 11:32:32 2017 +0900

    Merge pull request #114 from k-okada/add_unzip
    
    add unzip to build_depend
```