### PR TITLE
set default Debian-Version

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,4 +1,5 @@
 [catkin_pkg]
+Debian-Version: 100
 Depends: python-argparse, python-catkin-pkg-modules, python-dateutil, python-docutils
 Depends3: python3-catkin-pkg-modules, python3-dateutil, python3-docutils
 Conflicts: catkin, python3-catkin-pkg


### PR DESCRIPTION
Requires ros-infrastructure/ros_release_python#20.