### PR TITLE
[WIP][capability][generate_changelog] Add option to aggregate changelogs to metapkg.

### DIFF
--- a/src/catkin_pkg/changelog_generator_vcs.py
+++ b/src/catkin_pkg/changelog_generator_vcs.py
@@ -51,20 +51,38 @@ class Tag(object):
 
 class LogEntry(object):
 
-    def __init__(self, msg, affected_paths, author):
+    def __init__(self, msg, affected_paths, author, package_names=None):
         self.msg = msg
         self.author = author
         self._affected_paths = [p for p in affected_paths if p]
+        # List of package names that a log entry is associated with.
+        if package_names:
+            self._package_names = package_names
+        else:
+            self._package_names = []
 
     def affects_path(self, path):
+        #print('DEBUG) 550 path: {}\n\tself._affected_paths={}'.format(path, self._affected_paths))
         for apath in self._affected_paths:
             # if the path is the root of the repository
             # it is affected by all changes
+
+            print('DEBUG) 550 path={}'.format(path))
+            joined_path = os.path.join(path, '')  # e.g. moveit_planners/chomp/chomp_interface/
+            print('DEBUG) 551 joined_path={}'.format(joined_path))
+
             if path == '.':
                 return True
-            if apath.startswith(os.path.join(path, '')):
+            #if apath.startswith(os.path.join(path, '')):
+            if apath.startswith(joined_path):
                 return True
         return False
+
+    def add_package_name(self, package_name):
+        self._package_names.append(package_name)
+
+    def get_package_names(self):
+        return self._package_names
 
 
 class VcsClientBase(object):
@@ -205,6 +223,7 @@ class GitClient(VcsClientBase):
                 if result['returncode']:
                     raise RuntimeError('Could not fetch affected paths:\n%s' % result['output'])
                 affected_paths = result['output'].splitlines()
+                print('DEBUG) git result: {}\n\t\taffected_paths: {}'.format(result, affected_paths))
                 log_entries.append(LogEntry(msg, affected_paths, self._get_author(hash_)))
         return log_entries
 

--- a/src/catkin_pkg/cli/generate_changelog.py
+++ b/src/catkin_pkg/cli/generate_changelog.py
@@ -42,6 +42,8 @@ def main(sysargs=None):
     parser = argparse.ArgumentParser(description='Generate a REP-0132 %s' % CHANGELOG_FILENAME)
     parser.add_argument('-a', '--all', action='store_true', default=False,
         help='Generate changelog for all versions instead of only the forthcoming one (only supported when no changelog file exists yet)')
+    parser.add_argument('-g', '--aggregate', action='store_true',
+        default=False, help='Aggregate changelogs into the changelog file in metapackage(s).')
     parser.add_argument('--print-root', action='store_true', default=False,
         help='Output changelog content to the console as if there would be only one package in the root of the repository')
     parser.add_argument('--skip-contributors', action='store_true', default=False,
@@ -56,6 +58,9 @@ def main(sysargs=None):
     logging.basicConfig(format='%(message)s', level=logging.DEBUG)
 
     vcs_client = get_vcs_client(base_path)
+
+    # Whether or not to include package name in each log entry.
+    include_packagename = False
 
     if args.print_root:
         # printing status messages to stderr to allow piping the changelog to a file
@@ -99,6 +104,9 @@ def main(sysargs=None):
         if not args.non_interactive and not prompt_continue('Continue without --all option', default=False):
             raise RuntimeError('Skipping generation, rerun the script with --all.')
 
+    if args.aggregate:
+        include_packagename = True
+
     if args.all:
         print('Querying all tags and commit information...')
         tag2log_entries = get_all_changes(vcs_client, skip_merges=args.skip_merges)
@@ -115,7 +123,7 @@ def main(sysargs=None):
         packages_with = {pkg_path: package for pkg_path, package in packages.items() if package.name not in missing_changelogs}
         if packages_with:
             print('Updating forthcoming section of changelog files...')
-            update_changelogs(base_path, packages_with, tag2log_entries, logger=logging, vcs_client=vcs_client, skip_contributors=args.skip_contributors)
+            update_changelogs(base_path, packages_with, tag2log_entries, logger=logging, vcs_client=vcs_client, skip_contributors=args.skip_contributors, include_packagename=include_packagename)
     print('Done.')
     print('Please review the extracted commit messages and consolidate the changelog entries before committing the files!')
 

--- a/src/catkin_pkg/package.py
+++ b/src/catkin_pkg/package.py
@@ -173,6 +173,35 @@ class Package(object):
         """
         return 'metapackage' in [e.tagname for e in self.exports]
 
+    def get_depends(self):
+        '''
+        Returning all packages this package depends on.
+        @rtype: [catkin_pkg.package.Dependency]
+        @raises: InvalidPackage
+        '''
+        if self.package_format == 1:
+            return self.run_depends
+        elif self.package_format == 2:
+            return self.build_export_depends + self.exec_depends
+        else:
+            raise InvalidPackage('Manifest of package {} is in format = {} is not (yet) supported.'.format(self.name, self.package_format))
+
+    def includes_subpackage(self, file_path):
+        '''
+        @summary: Returns exception if this package is not a metapackage.
+                  Examine if the given file path is in a package that is
+                  included in this metapackage.
+        @param file_path: Relative path of the file to be examined.
+        @rtype: bool
+        '''
+        for pkg_dep in self.get_depends():
+            print('DEBUG)\tIs {} included in metapackage {}? Does {} start with {}?'.format(
+                pkg_dep, self.name, file_path, pkg_dep.name))
+            # if file_path.startswith(pkg_dep.name): # NG
+            if file_path.startswith(self.name): # NG. Only metapkgs get listed in logentry
+                return True
+        return False
+
     def validate(self, warnings=None):
         """
         makes sure all standards for packages are met

--- a/src/catkin_pkg/packages.py
+++ b/src/catkin_pkg/packages.py
@@ -86,6 +86,8 @@ def find_packages(basepath, exclude_paths=None, exclude_subspaces=False, warning
     packages = find_packages_allowing_duplicates(basepath, exclude_paths=exclude_paths, exclude_subspaces=exclude_subspaces, warnings=warnings)
     package_paths_by_name = {}
     for path, package in packages.items():
+        if isinstance(package, str):
+            print('DEBUG) 219 isinstance(package, str) YES with: {}'.format(package.name))
         if package.name not in package_paths_by_name:
             package_paths_by_name[package.name] = set([])
         package_paths_by_name[package.name].add(path)


### PR DESCRIPTION
**DO NOT code-review yet.** But opinion about this new feature is appreciated.

----

**Problem**

For a package suite that consists of larger set of packages, in which package the actual change is introduced might not always be clear if the changelogs are distributed in each package.

**Approach**

One or fewer central places for the large package suite where you can get a glimpse at all changes would be nice.
How about recording changelogs into metapackages?

In fact I've been manually doing the above (e.g. https://github.com/ros/rosdistro/pull/15326, which is propaged to [the wiki page of the same metapackage](http://docs.ros.org/lunar/changelogs/moveit/changelog.html)) and IMHO it gives better experience.

**Example**

Using `moveit`,

```
$ catkin_generate_changelog --aggregate
Found packages: chomp_motion_planner, moveit, moveit_commander, moveit_controller_manager_example, moveit_core, moveit_experimental, moveit_fake_controller_manager, moveit_kinematics, moveit_planners, moveit_planners_chomp, moveit_planners_ompl, moveit_plugins, moveit_ros, moveit_ros_benchmarks, moveit_ros_control_interface, moveit_ros_manipulation, moveit_ros_move_group, moveit_ros_perception, moveit_ros_planning, moveit_ros_planning_interface, moveit_ros_robot_interaction, moveit_ros_visualization, moveit_ros_warehouse, moveit_runtime, moveit_setup_assistant, moveit_simple_controller_manager
Querying commit information since latest tag...
:
Done.
Please review the extracted commit messages and consolidate the changelog entries before committing the files!
$
$ more moveit/CHANGELOG.rst 
^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Changelog for package moveit
^^^^^^^^^^^^^^^^^^^^^^^^^^^^

Forthcoming
-----------
* [moveit_setup_assistant] [moveit_ros] [moveit_core][moveit_plugins][moveit_planners] [setup_assistant] Fix for lunar (`#542 <https://github.com/ros-planning/moveit/issues/542>`_)
* [moveit_setup_assistant] [moveit_ros] [moveit_core][moveit_plugins][moveit_planners] Fix macro name (`#544 <https://github.com/ros-planning/moveit/issues/544>`_)
  Fix gcc warning introduced in `#535 <https://github.com/ros-planning/moveit/issues/535>`_
* [moveit_setup_assistant] [moveit_ros] [moveit_core][moveit_plugins][moveit_planners] Fixed doc-comment for robot_state::computeAABB (`#516 <https://github.com/ros-planning/moveit/issues/516>`_)
  The docstring says the format of the vector is `(minx, miny, minz, maxx, maxy, maxz)`, but according to both the method's implementation and use in moveit, the format is rather `(minx, maxx, miny, maxy, 
minz, maxz)`.
* [moveit_setup_assistant] [moveit_ros] [moveit_core][moveit_plugins][moveit_planners] check plan size (cleanup of `#492 <https://github.com/ros-planning/moveit/issues/492>`_) (`#535 <https://github.com/ro
s-planning/moveit/issues/535>`_)
  * check plan size
  * make plan_execution log output _NAMED
* [moveit_setup_assistant] [moveit_ros] [moveit_core][moveit_plugins][moveit_planners] [CI] Add ROS Lunar.
  In [lunar/Migration](http://wiki.ros.org/lunar/Migration), there's `robot_model` metapkg split. For now I doubt that it would affect CI jobs for Lunar in MoveIt!, but in case job fails then that might be
 one thing to look at.
* Contributors: Dave Coleman, Isaac I.Y. Saito, Martin Pecka, Michael Görner, Mikael Arguedas
:
```

Another metapackage in the same repo is also handled as intended:
```
$ more moveit_runtime/CHANGELOG.rst                                                                                            
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Changelog for package moveit_runtime
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

Forthcoming
-----------
* [moveit_planners] Chomp use PlanningScene (`#546 <https://github.com/ros-planning/moveit/issues/546>`_)
  * use the PlanningScene instance that is provided to the planner plugin
  further down the code this requires that the "global" PlanningScene uses
  the "Hybrid" collision checker from moveit-experimental. I will open a
  separate PR against moveit-resources to add this to the example
  Status after this fix:
  - chomp knows there are collisions
  - it tries and sometimes manages to avoid them
  - there is a ROS_ERROR informing you that the path still contains collisions
  - but it will still return SUCCESS
  * remove duplicate code
  * Search for config parameters in local namespace instead of global
* [moveit_planners] Change getCurrentExpectedTrajectory index so collision detection is s… (`#550 <https://github.com/ros-planning/moveit/issues/550>`_)
  * Change getCurrentExpectedTrajectory index so collision detection is still performed even if the path timing is not known
  * Reverted last change and modified case handling
  * Formatting file
  * Add comment
* [moveit_planners] Update README.md with ROS Lunar build badges (`#558 <https://github.com/ros-planning/moveit/issues/558>`_)
* [moveit_planners] Optional forced use of JointModelStateSpaceFactory (`#541 <https://github.com/ros-planning/moveit/issues/541>`_)
  * Implements optional ompl_planning config parameter 'force_joint_model_state_space'.
  * Renames parameter to 'enforce_joint_model_state_space'.
  Expands workaround comment.
* [moveit_planners] Add CONTRIBUTING.md file, set pull request expectations (`#557 <https://github.com/ros-planning/moveit/issues/557>`_)
* [moveit_plugins][moveit_planners] add backward compatibility patch for indigo (`#551 <https://github.com/ros-planning/moveit/issues/551>`_)
  ros_control changed their interface after indigo
* [moveit_plugins][moveit_planners] Merge pull request `#503 <https://github.com/ros-planning/moveit/issues/503>`_ from 130s/k/update_ci
  [CI] Add ROS Lunar.
* [moveit_plugins][moveit_planners] Add source and release docker images for lunar (`#536 <https://github.com/ros-planning/moveit/issues/536>`_)
* [moveit_core][moveit_plugins][moveit_planners] Fixing segfault due to missing string format parameter. (`#547 <https://github.com/ros-planning/moveit/issues/547>`_)
* [moveit_core][moveit_plugins][moveit_planners] [setup_assistant] Fix for lunar (`#542 <https://github.com/ros-planning/moveit/issues/542>`_)
* [moveit_core][moveit_plugins][moveit_planners] Fix macro name (`#544 <https://github.com/ros-planning/moveit/issues/544>`_)
  Fix gcc warning introduced in `#535 <https://github.com/ros-planning/moveit/issues/535>`_
* [moveit_core][moveit_plugins][moveit_planners] Fixed doc-comment for robot_state::computeAABB (`#516 <https://github.com/ros-planning/moveit/issues/516>`_)
  The docstring says the format of the vector is `(minx, miny, minz, maxx, maxy, maxz)`, but according to both the method's implementation and use in moveit, the format is rather `(minx, maxx, miny, maxy, 
minz, maxz)`.
* [moveit_core][moveit_plugins][moveit_planners] check plan size (cleanup of `#492 <https://github.com/ros-planning/moveit/issues/492>`_) (`#535 <https://github.com/ros-planning/moveit/issues/535>`_)
  * check plan size
  * make plan_execution log output _NAMED
:
```

**TODO**

- [ ] Implement the same feature for `--all` arg.
- [ ] Debug incl. https://github.com/ros-infrastructure/catkin_pkg/pull/188#issuecomment-320451240
- [ ] Add testcases.
- [ ] Code cleaning.
