### PR TITLE
[improve] Print package name when maintainer entry is missing.

### DIFF
--- a/src/catkin_pkg/package.py
+++ b/src/catkin_pkg/package.py
@@ -215,7 +215,7 @@ class Package(object):
             errors.append('Package description must not be empty')
 
         if not self.maintainers:
-            errors.append('Package must declare at least one maintainer')
+            errors.append('Package \'{}\' must declare at least one maintainer'.format(self.name))
         for maintainer in self.maintainers:
             try:
                 maintainer.validate()

--- a/src/catkin_pkg/package.py
+++ b/src/catkin_pkg/package.py
@@ -215,7 +215,7 @@ class Package(object):
             errors.append('Package description must not be empty')
 
         if not self.maintainers:
-            errors.append('Package \'{}\' must declare at least one maintainer'.format(self.name))
+            errors.append("Package '{}' must declare at least one maintainer".format(self.name))
         for maintainer in self.maintainers:
             try:
                 maintainer.validate()


### PR DESCRIPTION
E.g. when `rosdep install` hits a package where maintainer entry is missing, it only prints the error message without telling the package name. With this PR package name is printed too.

BEFORE this PR:
```
$ rosdep install -r -y --from-paths src --ignore-src

ERROR: Rosdep experienced an error: Package must declare at least one maintainer
Please go to the rosdep page [1] and file a bug report with the stack trace below.
[1] : http://www.ros.org/wiki/rosdep

rosdep version: 0.11.7

Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/rosdep2/main.py", line 137, in rosdep_main
    exit_code = _rosdep_main(args)
  File "/usr/lib/python2.7/dist-packages/rosdep2/main.py", line 383, in _rosdep_main
    return _package_args_handler(command, parser, options, args)
  File "/usr/lib/python2.7/dist-packages/rosdep2/main.py", line 436, in _package_args_handler
    pkgs = find_catkin_packages_in(path, options.verbose)
  File "/usr/lib/python2.7/dist-packages/rosdep2/catkin_packages.py", line 33, in find_catkin_packages_in
    packages = find_packages(path)
  File "/usr/lib/python2.7/dist-packages/catkin_pkg/packages.py", line 87, in find_packages
    packages = find_packages_allowing_duplicates(basepath, exclude_paths=exclude_paths, exclude_subspaces=exclude_subspaces, warnings=warnings)
  File "/usr/lib/python2.7/dist-packages/catkin_pkg/packages.py", line 144, in find_packages_allowing_duplicates
    path_parsed_packages, warnings_lists = zip(*pool.map(parser, data))
  File "/usr/lib/python2.7/multiprocessing/pool.py", line 251, in map
    return self.map_async(func, iterable, chunksize).get()
  File "/usr/lib/python2.7/multiprocessing/pool.py", line 558, in get
    raise self._value
InvalidPackage: Package must declare at least one maintainer
```

AFTER this PR:
```
$ rosdep install -r -y --from-paths src --ignore-src

ERROR: Rosdep experienced an error: Package aubo_trajectory_filters must declare at least one maintainer
Please go to the rosdep page [1] and file a bug report with the stack trace below.
[1] : http://www.ros.org/wiki/rosdep

rosdep version: 0.11.7

Traceback (most recent call last):
  File "/home/noodlemachine/ROS/ncws/src/ros-infrastructure/rosdep/src/rosdep2/main.py", line 137, in rosdep_main
    exit_code = _rosdep_main(args)
  File "/home/noodlemachine/ROS/ncws/src/ros-infrastructure/rosdep/src/rosdep2/main.py", line 384, in _rosdep_main
    return _package_args_handler(command, parser, options, args)
  File "/home/noodlemachine/ROS/ncws/src/ros-infrastructure/rosdep/src/rosdep2/main.py", line 437, in _package_args_handler
    pkgs = find_catkin_packages_in(path, options.verbose)
  File "/home/noodlemachine/ROS/ncws/src/ros-infrastructure/rosdep/src/rosdep2/catkin_packages.py", line 33, in find_catkin_packages_in
    packages = find_packages(path)
  File "/home/noodlemachine/ROS/ncws/src/ros-infrastructure/catkin_pkg/src/catkin_pkg/packages.py", line 86, in find_packages
    packages = find_packages_allowing_duplicates(basepath, exclude_paths=exclude_paths, exclude_subspaces=exclude_subspaces, warnings=warnings)
  File "/home/noodlemachine/ROS/ncws/src/ros-infrastructure/catkin_pkg/src/catkin_pkg/packages.py", line 143, in find_packages_allowing_duplicates
    path_parsed_packages, warnings_lists = zip(*pool.map(parser, data))
  File "/usr/lib/python2.7/multiprocessing/pool.py", line 251, in map
    return self.map_async(func, iterable, chunksize).get()
  File "/usr/lib/python2.7/multiprocessing/pool.py", line 558, in get
    raise self._value
InvalidPackage: Package aubo_trajectory_filters must declare at least one maintainer
```