### PR TITLE
chroot environment does not suport multithreading

### DIFF
--- a/src/catkin_pkg/packages.py
+++ b/src/catkin_pkg/packages.py
@@ -132,7 +132,6 @@ def find_packages_allowing_duplicates(basepath, exclude_paths=None, exclude_subs
     parallel = len(data) > 100
     if parallel:
         try:
-            parser = _PackageParser(warnings is not None)
             pool = multiprocessing.Pool()
         except OSError:
             # On chroot environment, multiprocessing is not available
@@ -141,6 +140,7 @@ def find_packages_allowing_duplicates(basepath, exclude_paths=None, exclude_subs
 
     if parallel:
         # use multiprocessing pool
+        parser = _PackageParser(warnings is not None)
         try:
             path_parsed_packages, warnings_lists = zip(*pool.map(parser, data))
         finally:

--- a/src/catkin_pkg/packages.py
+++ b/src/catkin_pkg/packages.py
@@ -129,11 +129,18 @@ def find_packages_allowing_duplicates(basepath, exclude_paths=None, exclude_subs
     if not data:
         return {}
 
-    try:
-        if len(data) < 100:
-            raise Error
-        parser = _PackageParser(warnings is not None)
-        pool = multiprocessing.Pool()
+    parallel = len(data) > 100
+    if parallel:
+        try:
+            parser = _PackageParser(warnings is not None)
+            pool = multiprocessing.Pool()
+        except OSError:
+            # On chroot environment, multiprocessing is not available
+            # https://stackoverflow.com/questions/6033599/oserror-38-errno-38-with-multiprocessing
+            parallel = False
+
+    if parallel:
+        # use multiprocessing pool
         try:
             path_parsed_packages, warnings_lists = zip(*pool.map(parser, data))
         finally:
@@ -142,7 +149,8 @@ def find_packages_allowing_duplicates(basepath, exclude_paths=None, exclude_subs
         if parser.capture_warnings:
             map(warnings.extend, warnings_lists)
         return dict(path_parsed_packages)
-    except:
+    else:
+        #  use sequential loop
         parsed_packages = {}
         for xml, path, filename in data:
             parsed_package = parse_package_string(


### PR DESCRIPTION
on some environment, python multithreading raise error with OSError38
(https://stackoverflow.com/questions/6033599/oserror-38-errno-38-with-multiprocessing)
In my case, I did chroot my environment and had this issue,

I'm not sure what is the best way to avoid this problem, here is a workaround by calling Lock() function and raise error when it is not available.

```
ERROR: Rosdep experienced an error: [Errno 38] Function not implemented
Please go to the rosdep page [1] and file a bug report with the stack trace belo
w.
[1] : http://www.ros.org/wiki/rosdep

rosdep version: 0.11.8

Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/rosdep2/main.py", line 137, in rosdep_m
ain
    exit_code = _rosdep_main(args)
  File "/usr/lib/python2.7/dist-packages/rosdep2/main.py", line 383, in _rosdep_
main
    return _package_args_handler(command, parser, options, args)
  File "/usr/lib/python2.7/dist-packages/rosdep2/main.py", line 458, in _package
_args_handler
    pkgs = find_catkin_packages_in(path, options.verbose)
  File "/usr/lib/python2.7/dist-packages/rosdep2/catkin_packages.py", line 33, i
n find_catkin_packages_in
    packages = find_packages(path)
  File "/usr/lib/python2.7/dist-packages/catkin_pkg/packages.py", line 87, in find_packages
    packages = find_packages_allowing_duplicates(basepath, exclude_paths=exclude_paths, exclude_subspaces=exclude_subspaces, warnings=warnings)
  File "/usr/lib/python2.7/dist-packages/catkin_pkg/packages.py", line 142, in find_packages_allowing_duplicates
    pool = multiprocessing.Pool()
  File "/usr/lib/python2.7/multiprocessing/__init__.py", line 232, in Pool
    return Pool(processes, initializer, initargs, maxtasksperchild)
  File "/usr/lib/python2.7/multiprocessing/pool.py", line 138, in __init__
    self._setup_queues()
  File "/usr/lib/python2.7/multiprocessing/pool.py", line 234, in _setup_queues
    self._inqueue = SimpleQueue()
  File "/usr/lib/python2.7/multiprocessing/queues.py", line 352, in __init__
    self._rlock = Lock()
  File "/usr/lib/python2.7/multiprocessing/synchronize.py", line 147, in __init__
    SemLock.__init__(self, SEMAPHORE, 1, 1)
  File "/usr/lib/python2.7/multiprocessing/synchronize.py", line 75, in __init__
    sl = self._semlock = _multiprocessing.SemLock(kind, value, maxvalue)
OSError: [Errno 38] Function not implemented
```