### PR TITLE
Fix UnicodeDecodeError

### DIFF
--- a/src/catkin_pkg/changelog.py
+++ b/src/catkin_pkg/changelog.py
@@ -193,8 +193,8 @@ def get_changelog_from_path(path, package_name=None):
     if os.path.isdir(path):
         path = os.path.join(path, CHANGELOG_FILENAME)
     try:
-        with open(path, 'r') as f:
-            populate_changelog_from_rst(changelog, f.read())
+        with open(path, 'rb') as f:
+            populate_changelog_from_rst(changelog, f.read().decode('utf-8'))
     except IOError:
         return None
     return changelog


### PR DESCRIPTION
Hi,

This PR fixes the ``UnicodeDecodeError`` which ``catkin_tag_changelog`` generates when the changelog includes a non-ascii character.
This might be related to #178. 

```bash
$ catkin_tag_changelog --bump minor
Found packages: test_pkg
Tag version 0.2.0
Renaming section 'Forthcoming' to '0.2.0 (2017-10-30)' in package 'test_pkg'...
Writing updated changelog files...
Traceback (most recent call last):
  File "/usr/bin/catkin_tag_changelog", line 9, in <module>
    load_entry_point('catkin-pkg==0.3.7', 'console_scripts', 'catkin_tag_changelog')()
  File "/usr/lib/python2.7/dist-packages/catkin_pkg/cli/tag_changelog.py", line 113, in main
    f.write(data.encode('utf-8'))
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe6 in position 135: ordinal not in range(128)
```
