### PR TITLE
[WIP] Support for parsing package format 3

### DIFF
--- a/src/catkin_pkg/package.py
+++ b/src/catkin_pkg/package.py
@@ -454,7 +454,7 @@ def parse_package_string(data, filename=None, warnings=None):
     # format attribute
     value = _get_node_attr(root, 'format', default=1)
     pkg.package_format = int(value)
-    assert pkg.package_format in [1, 2], "Unable to handle package.xml format version '%d', please update catkin_pkg (e.g. on Ubuntu/Debian use: sudo apt-get update && sudo apt-get install --only-upgrade python-catkin-pkg)" % pkg.package_format
+    assert pkg.package_format in [1, 2, 3], "Unable to handle package.xml format version '%d', please update catkin_pkg (e.g. on Ubuntu/Debian use: sudo apt-get update && sudo apt-get install --only-upgrade python-catkin-pkg)" % pkg.package_format
 
     # name
     pkg.name = _get_node_value(_get_node(root, 'name'))
@@ -569,13 +569,18 @@ def parse_package_string(data, filename=None, warnings=None):
         known.update({
             'run_depend': depend_attributes,
         })
-    if pkg.package_format == 2:
+    if pkg.package_format in [2, 3]:
         known.update({
             'build_export_depend': depend_attributes,
             'buildtool_export_depend': depend_attributes,
             'depend': depend_attributes,
             'exec_depend': depend_attributes,
             'doc_depend': depend_attributes,
+        })
+    if pkg.package_format == 3:
+        known.update({
+            'group_depend': [],
+            'member_of_group': []
         })
     nodes = [n for n in root.childNodes if n.nodeType == n.ELEMENT_NODE]
     unknown_tags = set([n.tagName for n in nodes if n.tagName not in known.keys()])

--- a/src/catkin_pkg/package.py
+++ b/src/catkin_pkg/package.py
@@ -505,7 +505,7 @@ def parse_package_string(data, filename=None, warnings=None):
         for d in run_depends:
             pkg.build_export_depends.append(deepcopy(d))
             pkg.exec_depends.append(deepcopy(d))
-    if pkg.package_format == 2:
+    if pkg.package_format in [2, 3]:
         pkg.build_export_depends = _get_dependencies(root, 'build_export_depend')
         pkg.buildtool_export_depends = _get_dependencies(root, 'buildtool_export_depend')
         pkg.exec_depends = _get_dependencies(root, 'exec_depend')


### PR DESCRIPTION
🚧 WIP. Do not merge. 🚧 

This PR adds the minimum changes necessary to run bloom, and soon the ROS 2 buildfarm supporting the package format 3 from in https://github.com/ros-infrastructure/rep/pull/138

At the moment the goal of this branch is to successfully parse format 3 packages without errors and is not intended to intended to bring complete support for format 3.