### PR TITLE
Extract exception message in python2/3 compatible way.

### DIFF
--- a/src/catkin_pkg/package.py
+++ b/src/catkin_pkg/package.py
@@ -473,7 +473,7 @@ def parse_package(path, warnings=None):
     try:
         return parse_package_string(xml, filename, warnings=warnings)
     except InvalidPackage as e:
-        e.args = ['Invalid package manifest "%s": %s' % (filename, e.message)]
+        e.args = ['Invalid package manifest "{0}": {1}'.format(filename, e)]
         raise
 
 

--- a/test/data/package/invalid_package.xml
+++ b/test/data/package/invalid_package.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<package>
+  <bad_tag>foo</bad_tag>
+</package>

--- a/test/data/package/valid_package.xml
+++ b/test/data/package/valid_package.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<package>
+  <name>valid_package</name>
+  <version>0.1.0</version>
+  <description>valid_package description</description>
+
+  <maintainer email="user@todo.todo">user</maintainer>
+  <license>BSD</license>
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <run_depend>foo</run_depend>
+  <run_depend>bar</run_depend>
+  <run_depend>baz</run_depend>
+</package>


### PR DESCRIPTION
In python3, `Exception` has no message attribute anymore. Instead, we should just rely on `__str__()` to give the message. Note that the `message` attribute isn't documented for python2 either.

I also replaced percent formatting with `str.format()` since that is now the preferred method and I noticed it is already used within the same file.

To test that this PR works as intended in python 2 and 3 I ran this script with both versions:
```python
class InvalidPackage(Exception):
	pass

try:
	raise InvalidPackage('lientje leerde lotje lopen langs de lange lindelaan')
except InvalidPackage as e:
	print('{}'.format(e))         # works in python 2 and 3
	print('{}'.format(e.message)) # works only in python 2
```

The result when running:
```
$ python2 ./test.py
lientje leerde lotje lopen langs de lange lindelaan
lientje leerde lotje lopen langs de lange lindelaan
```

```
$ python3 ./test.py
lientje leerde lotje lopen langs de lange lindelaan
Traceback (most recent call last):
  File "./test.py", line 5, in <module>
    raise InvalidPackage('lientje leerde lotje lopen langs de lange lindelaan')
__main__.InvalidPackage: lientje leerde lotje lopen langs de lange lindelaan

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "./test.py", line 8, in <module>
    print('{}'.format(e.message))
AttributeError: 'InvalidPackage' object has no attribute 'message'
```
