### PR TITLE
WIP: Add warning when circular dependency found.

### DIFF
--- a/src/catkin_pkg/topological_order.py
+++ b/src/catkin_pkg/topological_order.py
@@ -278,6 +278,8 @@ def _sort_decorated_packages(packages_orig):
             # the names list of remaining package names, with path
             # None to indicate cycle
             ordered_packages.append([None, ', '.join(sorted(_reduce_cycle_set(packages)))])
+            pkgs_circular = [pobj for pname, pobj in ordered_packages if not pname]
+            print("WARNING: cicular dependency found in {}".format(pkgs_circular))
             break
 
         # alphabetic order only for convenience


### PR DESCRIPTION
**Issue**
Even when there are pkgs that include circular dependency, `topological_order_packages` returns a list without specifically trying to raise an attention. Because of that, call at some downstream functions that don't handle circular dependency fail without meaningful info (e.g. catkin/catkin_tools#430).

**Approach**
Print the name of packages that include circular dependency.

**Output Sample**

```
$ catkin build pkg_aa
:
Workspace configuration appears valid.
-------------------------------------------------------------------
[build] Found '22' packages in 0.0 seconds.
Traceback (most recent call last):
File "/usr/bin/catkin", line 9, in <module>
load_entry_point('catkin-tools==0.4.4', 'console_scripts', 'catkin')()
  File "/usr/lib/python2.7/dist-packages/catkin_tools/commands/catkin.py", line 267, in main
    catkin_main(sysargs)
  File "/usr/lib/python2.7/dist-packages/catkin_tools/commands/catkin.py", line 262, in catkin_main
    sys.exit(args.main(args) or 0)
  File "/usr/lib/python2.7/dist-packages/catkin_tools/verbs/catkin_build/cli.py", line 420, in main
    summarize_build=opts.summarize  # Can be True, False, or None
  File "/usr/lib/python2.7/dist-packages/catkin_tools/verbs/catkin_build/build.py", line 305, in build_isolated_workspace
    packages, context, workspace_packages)
  File "/usr/lib/python2.7/dist-packages/catkin_tools/verbs/catkin_build/build.py", line 98, in determine_packages_to_be_built
    workspace_package_names = dict([(pkg.name, (path, pkg)) for path, pkg in ordered_packages])
AttributeError: 'str' object has no attribute 'name'
```

AFTER (notice there's WARNING)

```
$ catkin build pkg_aa
:
[build] Found '22' packages in 0.0 seconds.
WARNING: cicular dependency found in ['rqt_exposure_utility']
Traceback (most recent call last):
File "/usr/bin/catkin", line 9, in <module>
load_entry_point('catkin-tools==0.4.4', 'console_scripts', 'catkin')()
  File "/usr/lib/python2.7/dist-packages/catkin_tools/commands/catkin.py", line 267, in main
    catkin_main(sysargs)
  File "/usr/lib/python2.7/dist-packages/catkin_tools/commands/catkin.py", line 262, in catkin_main
    sys.exit(args.main(args) or 0)
  File "/usr/lib/python2.7/dist-packages/catkin_tools/verbs/catkin_build/cli.py", line 420, in main
    summarize_build=opts.summarize  # Can be True, False, or None
  File "/usr/lib/python2.7/dist-packages/catkin_tools/verbs/catkin_build/build.py", line 305, in build_isolated_workspace
    packages, context, workspace_packages)
  File "/usr/lib/python2.7/dist-packages/catkin_tools/verbs/catkin_build/build.py", line 98, in determine_packages_to_be_built
    workspace_package_names = dict([(pkg.name, (path, pkg)) for path, pkg in ordered_packages])
AttributeError: 'str' object has no attribute 'name'
```

**TODO**
- [ ] Test case.