### PR TITLE
InvalidPackage with package name

### DIFF
--- a/src/catkin_pkg/package.py
+++ b/src/catkin_pkg/package.py
@@ -677,7 +677,7 @@ def _get_nodes(parent, tagname):
 def _get_node(parent, tagname, filename):
     nodes = _get_nodes(parent, tagname)
     if len(nodes) != 1:
-        raise InvalidPackage('The manifest must contain exactly one "%s" tags' % tagname, filename)
+        raise InvalidPackage('The manifest must contain exactly one "%s" tag' % tagname, filename)
     return nodes[0]
 
 

--- a/src/catkin_pkg/package.py
+++ b/src/catkin_pkg/package.py
@@ -470,11 +470,7 @@ def parse_package(path, warnings=None):
     :raises: :exc:`IOError`
     """
     xml, filename = _get_package_xml(path)
-    try:
-        return parse_package_string(xml, filename, warnings=warnings)
-    except InvalidPackage as e:
-        e.args = ['Invalid package manifest "{0}": {1}'.format(filename, e)]
-        raise
+    return parse_package_string(xml, filename, warnings=warnings)
 
 
 def _check_known_attributes(node, known):
@@ -486,6 +482,7 @@ def _check_known_attributes(node, known):
             return ['The "%s" tag must not have the following attributes: %s' % (node.tagName, ', '.join(unknown_attrs))]
     return []
 
+
 def parse_package_string(data, filename=None, warnings=None):
     """
     Parse package.xml string contents.
@@ -496,6 +493,14 @@ def parse_package_string(data, filename=None, warnings=None):
     :returns: return parsed :class:`Package`
     :raises: :exc:`InvalidPackage`
     """
+    try:
+        return _parse_package_string(data, filename=filename, warnings=warnings)
+    except InvalidPackage as e:
+        e.args = ('Invalid package manifest "{0}": {1}'.format(filename, e),)
+        raise
+
+
+def _parse_package_string(data, filename=None, warnings=None):
     try:
         root = dom.parseString(data)
     except Exception as ex:
@@ -659,7 +664,7 @@ def parse_package_string(data, filename=None, warnings=None):
                 errors.append('The "%s" tag must not contain the following children: %s' % (node.tagName, ', '.join([n.tagName for n in subnodes])))
 
     if errors:
-        raise InvalidPackage('Error(s) in %s:%s' % (filename, ''.join(['\n- %s' % e for e in errors])))
+        raise InvalidPackage('Error(s):%s' % (''.join(['\n- %s' % e for e in errors])))
 
     pkg.validate(warnings=warnings)
 

--- a/src/catkin_pkg/package.py
+++ b/src/catkin_pkg/package.py
@@ -209,6 +209,13 @@ class Package(object):
         :param warnings: Print warnings if None or return them in the given list
         :raises InvalidPackage: in case validation fails
         """
+        try:
+            self._validate(warnings)
+        except InvalidPackage as e:
+            e.args = ('Invalid package manifest "{0}": {1}'.format(self.filename, e),)
+            raise
+
+    def _validate(self, warnings):
         errors = []
         new_warnings = []
 
@@ -224,7 +231,7 @@ class Package(object):
         else:
             if not re.match('^[a-z][a-z0-9_-]*$', self.name):
                 new_warnings.append(
-                    'Package name "%s" does not follow the naming conventions. It should start with'
+                    'Package name "%s" does not follow the naming conventions. It should start with '
                     'a lower case letter and only contain lower case letters, digits, underscores, and dashes.' % self.name)
 
         version_regexp = '^[0-9]+\.[0-9]+\.[0-9]+$'

--- a/src/catkin_pkg/python_setup.py
+++ b/src/catkin_pkg/python_setup.py
@@ -112,7 +112,7 @@ def generate_distutils_setup(package_xml_path=os.path.curdir, **kwargs):
     for k, v in kwargs.items():
         if k in data:
             if v != data[k]:
-                raise InvalidPackage('The keyword argument "%s" does not match the information from package.xml: "%s" != "%s"' % (k, v, data[k]))
+                raise InvalidPackage('The keyword argument "%s" does not match the information from package.xml: "%s" != "%s"' % (k, v, data[k]), package_xml_path)
         else:
             data[k] = v
 

--- a/test/test_package.py
+++ b/test/test_package.py
@@ -261,6 +261,18 @@ class PackageTest(unittest.TestCase):
             self.assertRaises(InvalidPackage, Package.validate, pack)
             dep_type.remove(depend)
 
+    def test_invalid_package_exception(self):
+        try:
+            raise InvalidPackage('foo')
+        except InvalidPackage as e:
+            self.assertEqual('foo', str(e))
+            self.assertEqual(None, e.package_path)
+        try:
+            raise InvalidPackage('foo', package_path='\\bar')
+        except InvalidPackage as e:
+            self.assertEqual('Error(s) in package \'\\bar\':\nfoo', str(e))
+            self.assertEqual('\\bar', e.package_path)
+
     def test_validate_person(self):
         auth1 = Person('foo')
         auth1.email = 'foo@bar.com'

--- a/test/test_packages.py
+++ b/test/test_packages.py
@@ -1,21 +1,38 @@
 import os
 
+from catkin_pkg.package import InvalidPackage
+
+from catkin_pkg.packages import find_packages
 from catkin_pkg.packages import find_package_paths
 from catkin_pkg.packages import find_packages_allowing_duplicates
 
 from .util import in_temporary_directory
 
+def _create_pkg_in_dir(path, version='0.1.0'):
+    path = os.path.abspath(path)
+    os.makedirs(path)
 
-def _create_pkg_in_dir(path):
-    os.mkdir(path)
-    open(os.path.join(path, 'package.xml'), 'a').close()
+    template = """\
+<?xml version="1.0"?>
+<package>
+  <name>{0}</name>
+  <version>{1}</version>
+  <description>Package {0}</description>
+  <license>BSD</license>
+
+  <maintainer email="foo@bar.com">Foo Bar</maintainer>
+</package>
+""".format(path.split('/')[-1], version)
+
+    with open(os.path.join(path, 'package.xml'), 'w+') as f:
+        f.write(template)
 
 @in_temporary_directory
 def test_package_paths_with_hidden_directories():
-    _create_pkg_in_dir('.test1');
-    _create_pkg_in_dir('.test2');
-    _create_pkg_in_dir('test3'); # not hidden
-    _create_pkg_in_dir('.test4');
+    _create_pkg_in_dir('.test1')
+    _create_pkg_in_dir('.test2')
+    _create_pkg_in_dir('test3')  # not hidden
+    _create_pkg_in_dir('.test4')
 
     res = find_package_paths('.')
     assert res == ['test3']
@@ -25,3 +42,16 @@ def test_find_packages_allowing_duplicates_with_no_packages():
     res = find_packages_allowing_duplicates('.')
     assert isinstance(res, dict)
     assert not res
+
+@in_temporary_directory
+def test_find_packages_invalid_version():
+    version = ':{version}'
+    path = 'src/foo'
+    _create_pkg_in_dir(path, version)
+    try:
+        find_packages(path.split('/')[0])
+        assert False, 'Must raise'
+    except InvalidPackage as e:
+        exception_message = str(e)
+        assert version in exception_message
+        assert path in exception_message


### PR DESCRIPTION
`parse_package_string()` raises `InvalidPackage` exception with the package name in the message.

This work is needed for [https://github.com/ros-infrastructure/rosdep/issues/598](https://github.com/ros-infrastructure/rosdep/issues/598)