### PR TITLE
Include package name in error message

### DIFF
--- a/src/catkin_pkg/package.py
+++ b/src/catkin_pkg/package.py
@@ -277,7 +277,7 @@ class Package(object):
         for dep_type, depends in dep_types.items():
             for depend in depends:
                 if depend.name == self.name:
-                    errors.append('The package must not "%s_depend" on a package with the same name as this package' % dep_type)
+                    errors.append('The package %s must not "%s_depend" on a package with the same name as this package' % (self.name, dep_type))
 
         if (
             set([d.name for d in self.group_depends]) &

--- a/src/catkin_pkg/package.py
+++ b/src/catkin_pkg/package.py
@@ -277,7 +277,7 @@ class Package(object):
         for dep_type, depends in dep_types.items():
             for depend in depends:
                 if depend.name == self.name:
-                    errors.append('The package %s must not "%s_depend" on a package with the same name as this package' % (self.name, dep_type))
+                    errors.append('The package "%s" must not "%s_depend" on a package with the same name as this package' % (self.name, dep_type))
 
         if (
             set([d.name for d in self.group_depends]) &


### PR DESCRIPTION
It is not trivial which package the error is referring to. All roslaunch calls fail if one package is not correct. So I included the package name in the error message for faster debugging.