### PR TITLE
Fix permission denied issue on Windows

### DIFF
--- a/test/test_package_version.py
+++ b/test/test_package_version.py
@@ -9,9 +9,9 @@ from catkin_pkg.package_version import bump_version
 from catkin_pkg.package_version import update_changelog_sections
 from catkin_pkg.package_version import update_versions
 
-from .util import in_temporary_directory
-
 import mock
+
+from .util import in_temporary_directory
 
 
 class PackageVersionTest(unittest.TestCase):
@@ -66,8 +66,7 @@ class PackageVersionTest(unittest.TestCase):
     @in_temporary_directory
     def test_update_changelog_unicode(self, directory=None):
         """Test that updating the changelog does not throw an exception on unicode characters."""
-        fd, temp_file = tempfile.mkstemp(dir=directory)
-        os.close(fd)
+        temp_file = os.path.join(directory, 'changelog')
         missing_changelogs_but_forthcoming = {}
         # Mock the Changelog object from catkin_pkg
         mock_changelog = mock.Mock()

--- a/test/test_package_version.py
+++ b/test/test_package_version.py
@@ -9,6 +9,8 @@ from catkin_pkg.package_version import bump_version
 from catkin_pkg.package_version import update_changelog_sections
 from catkin_pkg.package_version import update_versions
 
+from .util import temporary_file
+
 import mock
 
 
@@ -63,7 +65,7 @@ class PackageVersionTest(unittest.TestCase):
 
     def test_update_changelog_unicode(self):
         """Test that updating the changelog does not throw an exception on unicode characters."""
-        with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+        with temporary_file() as temp_file:
             missing_changelogs_but_forthcoming = {}
             # Mock the Changelog object from catkin_pkg
             mock_changelog = mock.Mock()

--- a/test/test_package_version.py
+++ b/test/test_package_version.py
@@ -63,7 +63,7 @@ class PackageVersionTest(unittest.TestCase):
 
     def test_update_changelog_unicode(self):
         """Test that updating the changelog does not throw an exception on unicode characters."""
-        with tempfile.NamedTemporaryFile() as temp_file:
+        with tempfile.NamedTemporaryFile(delete=False) as temp_file:
             missing_changelogs_but_forthcoming = {}
             # Mock the Changelog object from catkin_pkg
             mock_changelog = mock.Mock()

--- a/test/util.py
+++ b/test/util.py
@@ -34,3 +34,17 @@ def in_temporary_directory(f):
             return f(*args, **kwds)
     decorated.__name__ = f.__name__
     return decorated
+
+class temporary_file():
+
+    def __init__(self):
+        pass
+
+    def __enter__(self):
+        self.temp_file = tempfile.NamedTemporaryFile(delete=False)
+        return self.temp_file
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if self.temp_file and os.path.exists(self.temp_file.name):
+            self.temp_file.close()
+            os.remove(self.temp_file.name)

--- a/test/util.py
+++ b/test/util.py
@@ -16,10 +16,11 @@ class temporary_directory(object):
         return self.temp_path
 
     def __exit__(self, exc_type, exc_value, traceback):
-        if self.temp_path and os.path.exists(self.temp_path):
-            shutil.rmtree(self.temp_path)
+        # in Windows, current directory needs to be changed back to release the file handle.
         if self.original_cwd and os.path.exists(self.original_cwd):
             os.chdir(self.original_cwd)
+        if self.temp_path and os.path.exists(self.temp_path):
+            shutil.rmtree(self.temp_path)
 
 
 def in_temporary_directory(f):
@@ -34,17 +35,3 @@ def in_temporary_directory(f):
             return f(*args, **kwds)
     decorated.__name__ = f.__name__
     return decorated
-
-class temporary_file():
-
-    def __init__(self):
-        pass
-
-    def __enter__(self):
-        self.temp_file = tempfile.NamedTemporaryFile(delete=False)
-        return self.temp_file
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        if self.temp_file and os.path.exists(self.temp_file.name):
-            self.temp_file.close()
-            os.remove(self.temp_file.name)


### PR DESCRIPTION
The file created (and opened) by NamedTemporaryFile will be used in update_changelog_sections later and the second-time open() on the temp file will result in a permission denied on Windows because of Python implementation. The issue has been discussed here: https://bugs.python.org/issue14243

And one workaround talked about in the discussion is to pass "delete=False".

Here is the error messages for the test failure:

======================================================================
ERROR: test_update_changelog_unicode (test.test_package_version.PackageVersionTest)
Test that updating the changelog does not throw an exception on unicode characters.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "c:\workspace\catkin_pkg\test\test_package_version.py", line 87, in test_update_changelog_unicode
    update_changelog_sections(missing_changelogs_but_forthcoming, '1.0.0')
  File "c:\workspace\catkin_pkg\src\catkin_pkg\package_version.py", line 160, in update_changelog_sections
    with open(changelog_path, 'wb') as f:
IOError: [Errno 13] Permission denied: 'c:\\users\\admin\\appdata\\local\\temp\\tmpvchrip'