### PR TITLE
remove Ubuntu distros older than Trusty, remove Debian Wheezy

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -11,7 +11,7 @@ Depends3: python3-catkin-pkg-modules (>= 0.4.8), python3-dateutil, python3-docut
 Conflicts: catkin, python3-catkin-pkg
 Conflicts3: catkin, python-catkin-pkg
 Copyright-File: LICENSE
-Suite: oneiric precise quantal raring saucy trusty utopic vivid wily xenial yakkety zesty artful bionic wheezy jessie stretch buster
+Suite: trusty utopic vivid wily xenial yakkety zesty artful bionic jessie stretch buster
 X-Python3-Version: >= 3.2
 Setup-Env-Vars: SKIP_PYTHON_MODULES=1
 
@@ -24,6 +24,6 @@ Conflicts3: catkin, python3-catkin-pkg (<< 0.3.0)
 Replaces: python-catkin-pkg (<< 0.3.0)
 Replaces3: python3-catkin-pkg (<< 0.3.0)
 Copyright-File: LICENSE
-Suite: oneiric precise quantal raring saucy trusty utopic vivid wily xenial yakkety zesty artful bionic wheezy jessie stretch buster
+Suite: trusty utopic vivid wily xenial yakkety zesty artful bionic jessie stretch buster
 X-Python3-Version: >= 3.2
 Setup-Env-Vars: SKIP_PYTHON_SCRIPTS=1


### PR DESCRIPTION
Related to #232.

Basically the toolchain on Bionic embeds a Python dependency on version >= 2.7.5 which isn't available on Ubuntu Precise / Debian Wheezy. At the same time it removes other EOL Ubuntu distro before the last supported LTS which is currently Ubuntu Trusty.