### PR TITLE
Exclude generated documentation files from flake8 test

### DIFF
--- a/test/test_flake8.py
+++ b/test/test_flake8.py
@@ -24,6 +24,8 @@ def test_flake8():
     # Configure flake8 using the .flake8 file in the root of this repository.
     style_guide = get_style_guide()
 
+    style_guide.options.exclude += ['*/doc/_build']
+
     stdout = sys.stdout
     sys.stdout = sys.stderr
     # implicitly calls report_errors()


### PR DESCRIPTION
For whatever reason, the `conf.py` generated in the `doc/_build` directory on Fedora doesn't have a trailing newline, so it fails the flake8 tests. Of course this isn't a problem if you don't build docs before running the tests. There really isn't any reason to run flake8 on anything generated in the docs anyway, so we can just skip those files.