### PR TITLE
warn not error (fail) for people wrongly using run_depend on version 2

### DIFF
--- a/src/catkin_pkg/package.py
+++ b/src/catkin_pkg/package.py
@@ -605,6 +605,10 @@ def parse_package_string(data, filename=None, warnings=None):
             if not same_exec_depends:
                 pkg.exec_depends.append(deepcopy(dep))
         pkg.doc_depends = _get_dependencies(root, 'doc_depend')
+        for d in run_depends:
+            print('WARNING: The manifest of package "%s" (with format version %d) does not support <run_depend>%s</run_depend>. Please update your package.xml with <exec_depend>' % (pkg.name, pkg.package_format, d.name), file=sys.stderr)
+            pkg.build_export_depends.append(deepcopy(d))
+            pkg.exec_depends.append(deepcopy(d))
     pkg.test_depends = _get_dependencies(root, 'test_depend')
     pkg.conflicts = _get_dependencies(root, 'conflict')
     pkg.replaces = _get_dependencies(root, 'replace')

--- a/src/catkin_pkg/package.py
+++ b/src/catkin_pkg/package.py
@@ -674,6 +674,9 @@ def parse_package_string(data, filename=None, warnings=None):
         })
     nodes = [n for n in root.childNodes if n.nodeType == n.ELEMENT_NODE]
     unknown_tags = set([n.tagName for n in nodes if n.tagName not in known.keys()])
+    if unknown_tags == set(['run_depend']):
+        print('WARNING: The manifest of package "%s" (with format version %d) does not support run_depend. Please update your package.xml with exec_depend' % (pkg.name, pkg.package_format), file=sys.stderr)
+        unknown_tags.remove('run_depend')
     if unknown_tags:
         errors.append('The manifest (with format version %d) must not contain the following tags: %s' % (pkg.package_format, ', '.join(unknown_tags)))
     for node in [n for n in nodes if n.tagName in known.keys()]:


### PR DESCRIPTION
Using run_depend with package.xml is not supported, but failing with error is too much for new users, we have so many question related this issue ->  see [Gogle result](https://www.google.co.jp/search?ei=JJG1W-GsMo_b8APs1J3gBg&q=the+manifest+%28with+format+version+2%29+must+not+contain+the+following+tags%3A+run_depend%22&oq=the+manifest+%28with+format+version+2%29+must+not+contain+the+following+tags%3A+run_depend%22 )

Note that we have not updated the translated tutorial which still assuming version 1, but actutal `catkin_create_pkg` has been updated for version  http://wiki.ros.org/ja/ROS/Tutorials/CreatingMsgAndSrv