### PR TITLE
Remove argparse Dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,19 @@
 #!/usr/bin/env python
 
 import os
+import sys
 
 from setuptools import setup
+
+install_requires = [
+    'docutils',
+    'python-dateutil',
+    'pyparsing',
+]
+
+# argparse is part of the standard library since Python 2.7
+if sys.version_info[0] == 2 and sys.version_info[1] <= 7:
+    install_requires.append('argparse')
 
 kwargs = {
     'name': 'catkin_pkg',
@@ -34,12 +45,7 @@ kwargs = {
     'description': 'catkin package library',
     'long_description': 'Library for retrieving information about catkin packages.',
     'license': 'BSD',
-    'install_requires': [
-        'argparse',
-        'docutils',
-        'python-dateutil',
-        'pyparsing',
-    ],
+    'install_requires': install_requires,
 }
 if 'SKIP_PYTHON_MODULES' in os.environ:
     kwargs['packages'] = []


### PR DESCRIPTION
Since `argparse` is now a part of the language, runtime problems result from this (see ros/ros-overlay#687).