### PR TITLE
Test for metapackage with format 2

### DIFF
--- a/src/catkin_pkg/package.py
+++ b/src/catkin_pkg/package.py
@@ -293,7 +293,8 @@ class Package(object):
                 new_warnings.append('Metapackage "%s" must buildtool_depend on catkin.' % self.name)
             if self.has_invalid_metapackage_dependencies():
                 new_warnings.append('Metapackage "%s" should not have other dependencies besides a '
-                                    'buildtool_depend on catkin and run_depends.' % self.name)
+                                    'buildtool_depend on catkin and %s.' %
+                                    (self.name, 'run_depends' if self.package_format == 1 else 'exec_depends'))
 
         for warning in new_warnings:
             if warnings is None:

--- a/test/data/metapackages/valid_metapackage_format2/CMakeLists.txt
+++ b/test/data/metapackages/valid_metapackage_format2/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(valid_metapackage_format2)
+find_package(catkin REQUIRED)
+catkin_metapackage()

--- a/test/data/metapackages/valid_metapackage_format2/package.xml
+++ b/test/data/metapackages/valid_metapackage_format2/package.xml
@@ -1,0 +1,17 @@
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="2">
+  <name>valid_metapackage_format2</name>
+  <version>0.1.0</version>
+  <description>valid_metapackage</description>
+
+  <maintainer email="user@todo.todo">user</maintainer>
+  <license>BSD</license>
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <exec_depend>foo</exec_depend>
+
+  <export>
+    <metapackage/>
+  </export>
+
+</package>

--- a/test/test_metapackage.py
+++ b/test/test_metapackage.py
@@ -28,7 +28,8 @@ test_expectations = {
     'no_cmake': [InvalidMetapackage, 'No CMakeLists.txt', None],
     'no_metapackage_tag': [InvalidMetapackage, 'No <metapackage/> tag in <export>', None],
     'NonConformingName': [None, None, None],
-    'valid_metapackage': [None, None, None]
+    'valid_metapackage': [None, None, None],
+    'valid_metapackage_format2': [None, None, None],
 }
 
 test_expected_warnings = [


### PR DESCRIPTION
Produce different warning message for dependencies in format 1 (has to have `run_depends`) and formats 2 and 2 (`exec_depends`)