### PR TITLE
Fix argparse requirement for python 2.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ install_requires = [
 ]
 
 # argparse is part of the standard library since Python 2.7
-if sys.version_info[0] == 2 and sys.version_info[1] <= 7:
+if sys.version_info[0] == 2 and sys.version_info[1] < 7:
     install_requires.append('argparse')
 
 kwargs = {


### PR DESCRIPTION
From https://pypi.org/project/argparse:
>As of Python >= 2.7 and >= 3.2, the argparse module is maintained within the Python standard library.