### PR TITLE
[Windows] Disable multiprocessing usage for package.py on Windows

### DIFF
--- a/src/catkin_pkg/packages.py
+++ b/src/catkin_pkg/packages.py
@@ -134,7 +134,7 @@ def find_packages_allowing_duplicates(basepath, exclude_paths=None, exclude_subs
     if not data:
         return {}
 
-    parallel = False if sys.platform == 'win32' else len(data) > 100
+    parallel = len(data) > 100 if sys.platform != 'win32' else False
     if parallel:
         try:
             pool = multiprocessing.Pool()

--- a/src/catkin_pkg/packages.py
+++ b/src/catkin_pkg/packages.py
@@ -133,7 +133,7 @@ def find_packages_allowing_duplicates(basepath, exclude_paths=None, exclude_subs
     if not data:
         return {}
 
-    parallel = len(data) > 100
+    parallel = len(data) > 9999
     if parallel:
         try:
             pool = multiprocessing.Pool()

--- a/src/catkin_pkg/packages.py
+++ b/src/catkin_pkg/packages.py
@@ -34,6 +34,7 @@
 
 import multiprocessing
 import os
+import sys
 
 from .package import _get_package_xml
 from .package import PACKAGE_MANIFEST_FILENAME
@@ -133,7 +134,7 @@ def find_packages_allowing_duplicates(basepath, exclude_paths=None, exclude_subs
     if not data:
         return {}
 
-    parallel = len(data) > 9999
+    parallel = False if sys.platform == 'win32' else len(data) > 100
     if parallel:
         try:
             pool = multiprocessing.Pool()


### PR DESCRIPTION
On Windows, the multiprocessing will require the script who consumes the catkin_pkg to be patched in order to work properly.

Instead of touching up all the scripts consuming catkin_pkg, disable multiprocessing on Windows. Otherwise, catkin_pkg won't work for a workspace with more than 100 packages on Windows.

```
Traceback (most recent call last):
  File "F:\workspace\catkin_pkg\test\test_metapackage.py", line 76, in test_validate_metapackage
    pkgs_dict = find_packages(test_data_dir)
  File "f:\workspace\catkin_pkg\src\catkin_pkg\packages.py", line 90, in find_packages
    packages = find_packages_allowing_duplicates(basepath, exclude_paths=exclude_paths, exclude_subspaces=exclude_subspaces, warnings=warnings)
  File "f:\workspace\catkin_pkg\src\catkin_pkg\packages.py", line 141, in find_packages_allowing_duplicates
    pool = multiprocessing.Pool()
  File "C:\Python27\lib\multiprocessing\__init__.py", line 232, in Pool
    return Pool(processes, initializer, initargs, maxtasksperchild)
  File "C:\Python27\lib\multiprocessing\pool.py", line 161, in __init__
    self._repopulate_pool()
  File "C:\Python27\lib\multiprocessing\pool.py", line 225, in _repopulate_pool
    w.start()
  File "C:\Python27\lib\multiprocessing\process.py", line 130, in start
    self._popen = Popen(self)
  File "C:\Python27\lib\multiprocessing\forking.py", line 258, in __init__
    cmd = get_command_line() + [rhandle]
  File "C:\Python27\lib\multiprocessing\forking.py", line 358, in get_command_line
    is not going to be frozen to produce a Windows executable.''')
RuntimeError:
            Attempt to start a new process before the current process
            has finished its bootstrapping phase.

            This probably means that you are on Windows and you have
            forgotten to use the proper idiom in the main module:

                if __name__ == '__main__':
                    freeze_support()
                    ...

            The "freeze_support()" line can be omitted if the program
            is not going to be frozen to produce a Windows executable.
```