### PR TITLE
[Windows] Use multiprocessing.dummy on Windows for parallelism (plus adding Azure test pipeline.)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,27 @@
+jobs:
+- job: 'Build'
+  pool:
+    vmImage: 'vs2017-win2016'
+  strategy:
+    matrix:
+      Python27:
+        python.version: '2.7'
+      Python35:
+        python.version: '3.5'
+      Python36:
+        python.version: '3.6'
+  steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '$(python.version)'
+      architecture: 'x64'
+  - script: |
+      python -m pip install nose coverage argparse python-dateutil docutils pyparsing
+      python -m pip install flake8 flake8-blind-except flake8-builtins flake8-class-newline flake8-comprehensions flake8-deprecated flake8-docstrings flake8-import-order flake8-quotes
+      python -m pip install mock
+  - script: |
+      python -m nose --with-xunit
+  - task: PublishTestResults@2
+    condition: succeededOrFailed()
+    inputs:
+      testResultsFiles: '**/*.xml'

--- a/src/catkin_pkg/packages.py
+++ b/src/catkin_pkg/packages.py
@@ -33,6 +33,11 @@
 """Library to find packages in the filesystem."""
 
 import os
+
+from .package import _get_package_xml
+from .package import PACKAGE_MANIFEST_FILENAME
+from .package import parse_package_string
+
 if os.name == 'nt':
     # https://docs.python.org/2/library/multiprocessing.html#windows
     #
@@ -44,10 +49,6 @@ if os.name == 'nt':
     import multiprocessing.dummy as multiprocessing
 else:
     import multiprocessing
-
-from .package import _get_package_xml
-from .package import PACKAGE_MANIFEST_FILENAME
-from .package import parse_package_string
 
 
 def find_package_paths(basepath, exclude_paths=None, exclude_subspaces=False):

--- a/src/catkin_pkg/packages.py
+++ b/src/catkin_pkg/packages.py
@@ -32,8 +32,18 @@
 
 """Library to find packages in the filesystem."""
 
-import multiprocessing
 import os
+if os.name == 'nt':
+    # https://docs.python.org/2/library/multiprocessing.html#windows
+    #
+    # On Windows, using multiprocessing requires the scripts to be
+    # "Safe importing of main module" to avoid RuntimeError.
+    # This restriction requires downstream tools to be modified to
+    # work. Instead, let's fallback to threading wrapper to get
+    # around it and still keep the parallelism on Windows.
+    import multiprocessing.dummy as multiprocessing
+else:
+    import multiprocessing
 
 from .package import _get_package_xml
 from .package import PACKAGE_MANIFEST_FILENAME

--- a/test/test_packages.py
+++ b/test/test_packages.py
@@ -49,7 +49,7 @@ def test_find_packages_allowing_duplicates_with_no_packages():
 @in_temporary_directory
 def test_find_packages_invalid_version():
     version = ':{version}'
-    path = 'src/foo'
+    path = os.path.normpath('src/foo')
     _create_pkg_in_dir(path, version)
     try:
         find_packages(path.split('/')[0])

--- a/test/test_packages.py
+++ b/test/test_packages.py
@@ -52,7 +52,7 @@ def test_find_packages_invalid_version():
     path = os.path.normpath('src/foo')
     _create_pkg_in_dir(path, version)
     try:
-        find_packages(path.split('/')[0])
+        find_packages(path.split(os.sep)[0])
         assert False, 'Must raise'
     except InvalidPackage as e:
         exception_message = str(e)


### PR DESCRIPTION
This is an attempt to address the discussion in #250.

The change is to propose using multiprocessing.dummy (which is a threading wrapper) on Windows to avoid the restriction [`Safe importing of main module`](https://docs.python.org/2.7/library/multiprocessing.html#windows) (which requires the downstream tools to be updated to work). This way can keep parallelism but not requires the downstream tools to be modified.

Plus, this change adds an Azure pipeline yaml to exercise the test suite on Windows machines.