### PR TITLE
Fix parsing package.xml files with Unicode characters

### DIFF
--- a/src/catkin_pkg/package.py
+++ b/src/catkin_pkg/package.py
@@ -535,7 +535,7 @@ def parse_package_string(data, filename=None, warnings=None):
     :raises: :exc:`InvalidPackage`
     """
     try:
-        root = dom.parseString(data)
+        root = dom.parseString(data.encode('utf-8'))
     except Exception as ex:
         raise InvalidPackage('The manifest contains invalid XML:\n%s' % ex, filename)
 


### PR DESCRIPTION
Unicode characters in package.xml break `parse_package_string()`.
Here's an example traceback caused by a package where the author's
name contained an umlaut:

    Traceback (most recent call last):
      [...]
      File "/usr/lib/python2.7/dist-packages/catkin_pkg/package.py", line 540, in parse_package_string
        raise InvalidPackage('The manifest contains invalid XML:\n%s' % ex, filename)
    catkin_pkg.package.InvalidPackage: The manifest contains invalid XML:
    'ascii' codec can't encode character u'\xf6' in position 256: ordinal not in range(128)