### PR TITLE
support passing unicode to parse_package_string

### DIFF
--- a/src/catkin_pkg/package.py
+++ b/src/catkin_pkg/package.py
@@ -534,6 +534,8 @@ def parse_package_string(data, filename=None, warnings=None):
     :returns: return parsed :class:`Package`
     :raises: :exc:`InvalidPackage`
     """
+    if sys.version_info[0] == 2 and not isinstance(data, str):
+        data = data.encode('utf-8')
     try:
         root = dom.parseString(data)
     except Exception as ex:

--- a/test/data/package/valid_package.xml
+++ b/test/data/package/valid_package.xml
@@ -4,7 +4,7 @@
   <version>0.1.0</version>
   <description>valid_package description</description>
 
-  <maintainer email="user@todo.todo">user</maintainer>
+  <maintainer email="user@todo.todo">üser</maintainer>
   <license>BSD</license>
   <buildtool_depend>catkin</buildtool_depend>
 

--- a/test/test_package.py
+++ b/test/test_package.py
@@ -7,12 +7,14 @@ import xml.dom.minidom as dom
 
 from catkin_pkg.package import (
     _check_known_attributes,
+    _get_package_xml,
     Dependency,
     Export,
     InvalidPackage,
     License,
     Package,
     parse_package,
+    parse_package_string,
     Person,
 )
 
@@ -321,3 +323,18 @@ class PackageTest(unittest.TestCase):
     def test_parse_package_invalid(self):
         filename = os.path.join(test_data_dir, 'invalid_package.xml')
         self.assertRaises(InvalidPackage, parse_package, filename)
+
+    def test_parse_package_string(self):
+        filename = os.path.join(test_data_dir, 'valid_package.xml')
+        xml = _get_package_xml(filename)[0]
+
+        assert isinstance(xml, str)
+        parse_package_string(xml)
+
+        if sys.version_info[0] == 2:
+            xml = xml.decode('utf-8')
+            assert not isinstance(xml, str)
+        else:
+            xml = xml.encode('utf-8')
+            assert isinstance(xml, bytes)
+        parse_package_string(xml)


### PR DESCRIPTION
Redo of #252.

WIthout the patch the function `parse_package_string` works with:
* Python 2:
  * `str`
* Python 2:
  * `str`
  * `bytes`

With the patch it also works with `unicode` in Python 2.

The first commit adds the test coverage for the new use case (hence failing). The second commit implements the new support.