### PR TITLE
Make prerelease process work on Windows

### DIFF
--- a/src/catkin_pkg/changelog_generator.py
+++ b/src/catkin_pkg/changelog_generator.py
@@ -197,7 +197,7 @@ def get_version_section_match(data, version):
 def get_version_section_pattern(version):
     valid_section_characters = '!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~'
     headline = get_version_headline(version, None)
-    pattern = '^(' + re.escape(headline) + '( \([0-9 \-:|+]+\))?)\n([' + re.escape(valid_section_characters) + ']+)\n?$'
+    pattern = '^(' + re.escape(headline) + '( \([0-9 \-:|+]+\))?)\r?\n([' + re.escape(valid_section_characters) + ']+)\r?\n?$'
     return pattern
 
 

--- a/src/catkin_pkg/changelog_generator_vcs.py
+++ b/src/catkin_pkg/changelog_generator_vcs.py
@@ -65,6 +65,18 @@ class LogEntry(object):
         return False
 
 
+try:
+    from shutil import which
+except ImportError:
+    # fallback for python < 3.3
+    def which(cmd):
+        for path in os.getenv('PATH').split(os.path.pathsep):
+            file_path = os.path.join(path, cmd)
+            if os.path.isfile(file_path):
+                return file_path
+        return None
+
+
 class VcsClientBase(object):
 
     def __init__(self, path):
@@ -81,17 +93,6 @@ class VcsClientBase(object):
 
     def replace_repository_references(self, line):
         return line
-
-    def _find_executable(self, file_name):
-        try:
-            return shutil.which(file_name)
-        except AttributeError:
-            # fallback for Python < 3.3
-            for path in os.getenv('PATH').split(os.path.pathsep):
-                file_path = os.path.join(path, file_name)
-                if os.path.isfile(file_path):
-                    return file_path
-            return None
 
     def _run_command(self, cmd, env=None):
         cwd = os.path.abspath(self.path)
@@ -134,7 +135,7 @@ class GitClient(VcsClientBase):
 
     def __init__(self, path):
         super(GitClient, self).__init__(path)
-        self._executable = self._find_executable('git')
+        self._executable = which('git')
         self._repo_hosting = None
         self._github_base_url = 'https://github.com/'
         self._github_path = None
@@ -263,7 +264,7 @@ class HgClient(VcsClientBase):
 
     def __init__(self, path):
         super(HgClient, self).__init__(path)
-        self._executable = self._find_executable('hg')
+        self._executable = which('hg')
 
     # query author
     def _get_author(self, hash_):

--- a/src/catkin_pkg/changelog_generator_vcs.py
+++ b/src/catkin_pkg/changelog_generator_vcs.py
@@ -40,6 +40,18 @@ import subprocess
 import tempfile
 
 
+try:
+    from shutil import which
+except ImportError:
+    # fallback for Python < 3.3
+    def which(cmd):
+        for path in os.getenv('PATH').split(os.path.pathsep):
+            file_path = os.path.join(path, cmd)
+            if os.path.isfile(file_path):
+                return file_path
+        return None
+
+
 class Tag(object):
 
     def __init__(self, name, timestamp=None):
@@ -63,18 +75,6 @@ class LogEntry(object):
             if apath.startswith(os.path.join(path, '')):
                 return True
         return False
-
-
-try:
-    from shutil import which
-except ImportError:
-    # fallback for python < 3.3
-    def which(cmd):
-        for path in os.getenv('PATH').split(os.path.pathsep):
-            file_path = os.path.join(path, cmd)
-            if os.path.isfile(file_path):
-                return file_path
-        return None
 
 
 class VcsClientBase(object):

--- a/src/catkin_pkg/changelog_generator_vcs.py
+++ b/src/catkin_pkg/changelog_generator_vcs.py
@@ -353,7 +353,7 @@ def get_vcs_client(base_path):
     client_types = [c.type for c in vcs_clients]
     if len(client_types) != len(set(client_types)):
         raise RuntimeError('Multiple vcs clients share the same type: %s' % ', '.join(sorted(client_types)))
-    
+
     for vcs_client in vcs_clients:
         if os.path.exists(os.path.join(base_path, '.%s' % vcs_client.type)):
             return vcs_client(base_path)

--- a/src/catkin_pkg/changelog_generator_vcs.py
+++ b/src/catkin_pkg/changelog_generator_vcs.py
@@ -353,6 +353,7 @@ def get_vcs_client(base_path):
     client_types = [c.type for c in vcs_clients]
     if len(client_types) != len(set(client_types)):
         raise RuntimeError('Multiple vcs clients share the same type: %s' % ', '.join(sorted(client_types)))
+    
     for vcs_client in vcs_clients:
         if os.path.exists(os.path.join(base_path, '.%s' % vcs_client.type)):
             return vcs_client(base_path)

--- a/src/catkin_pkg/cli/prepare_release.py
+++ b/src/catkin_pkg/cli/prepare_release.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 import argparse
 import os
 import re
+import shutil
 import subprocess
 import sys
 
@@ -194,10 +195,16 @@ def push_changes(base_path, vcs_type, tag_name, dry_run=False):
 
 
 def _find_executable(vcs_type):
-    for path in os.getenv('PATH').split(os.path.pathsep):
-        file_path = os.path.join(path, vcs_type)
-        if os.path.isfile(file_path):
+    try:
+        file_path = shutil.which(vcs_type)
+        if file_path is not None:
             return file_path
+    except AttributeError:
+        # fallback for Python < 3.3
+        for path in os.getenv('PATH').split(os.path.pathsep):
+            file_path = os.path.join(path, vcs_type)
+            if os.path.isfile(file_path):
+                return file_path
     raise RuntimeError(fmt('@{rf}Could not find vcs binary: %s' % vcs_type))
 
 

--- a/src/catkin_pkg/cli/prepare_release.py
+++ b/src/catkin_pkg/cli/prepare_release.py
@@ -3,7 +3,6 @@ from __future__ import print_function
 import argparse
 import os
 import re
-import shutil
 import subprocess
 import sys
 
@@ -194,19 +193,24 @@ def push_changes(base_path, vcs_type, tag_name, dry_run=False):
     return commands
 
 
-def _find_executable(vcs_type):
-    try:
-        file_path = shutil.which(vcs_type)
-        if file_path is not None:
-            return file_path
-    except AttributeError:
-        # fallback for Python < 3.3
+try:
+    from shutil import which
+except ImportError:
+    # fallback for python < 3.3
+    def which(exe):
         for path in os.getenv('PATH').split(os.path.pathsep):
-            file_path = os.path.join(path, vcs_type)
+            file_path = os.path.join(path, exe)
             if os.path.isfile(file_path):
                 return file_path
-    raise RuntimeError(fmt('@{rf}Could not find vcs binary: %s' % vcs_type))
+        return None
 
+
+def _find_executable(vcs_type):
+    file_path = which(vcs_type)
+    if file_path is None:
+        raise RuntimeError(fmt('@{rf}Could not find vcs binary: %s' % vcs_type))
+    return file_path
+    
 
 def main():
     try:

--- a/src/catkin_pkg/cli/prepare_release.py
+++ b/src/catkin_pkg/cli/prepare_release.py
@@ -209,7 +209,7 @@ def _find_executable(vcs_type):
     if file_path is None:
         raise RuntimeError(fmt('@{rf}Could not find vcs binary: %s' % vcs_type))
     return file_path
-    
+
 
 def main():
     try:

--- a/src/catkin_pkg/cli/prepare_release.py
+++ b/src/catkin_pkg/cli/prepare_release.py
@@ -16,6 +16,17 @@ from catkin_pkg.terminal_color import disable_ANSI_colors, fmt
 from catkin_pkg.workspace_vcs import get_repository_type, vcs_remotes
 
 try:
+    from shutil import which
+except ImportError:
+    # fallback for python < 3.3
+    def which(exe):
+        for path in os.getenv('PATH').split(os.path.pathsep):
+            file_path = os.path.join(path, exe)
+            if os.path.isfile(file_path):
+                return file_path
+        return None
+
+try:
     raw_input
 except NameError:
     raw_input = input  # noqa: A001
@@ -191,18 +202,6 @@ def push_changes(base_path, vcs_type, tag_name, dry_run=False):
                 raise RuntimeError(fmt('@{rf}Failed to push tag to the repository: %s\n\nYou need to manually push the new tag to the repository.' % str(e)))
 
     return commands
-
-
-try:
-    from shutil import which
-except ImportError:
-    # fallback for python < 3.3
-    def which(exe):
-        for path in os.getenv('PATH').split(os.path.pathsep):
-            file_path = os.path.join(path, exe)
-            if os.path.isfile(file_path):
-                return file_path
-        return None
 
 
 def _find_executable(vcs_type):

--- a/src/catkin_pkg/cli/prepare_release.py
+++ b/src/catkin_pkg/cli/prepare_release.py
@@ -18,7 +18,7 @@ from catkin_pkg.workspace_vcs import get_repository_type, vcs_remotes
 try:
     from shutil import which
 except ImportError:
-    # fallback for python < 3.3
+    # fallback for Python < 3.3
     def which(exe):
         for path in os.getenv('PATH').split(os.path.pathsep):
             file_path = os.path.join(path, exe)

--- a/src/catkin_pkg/package_version.py
+++ b/src/catkin_pkg/package_version.py
@@ -167,7 +167,7 @@ def rename_section(data, old_label, new_label):
     def replace_section(match):
         section_char = match.group(2)[0]
         return new_label + '\n' + section_char * len(new_label)
-    pattern = '^(' + re.escape(old_label) + ')\n([' + re.escape(valid_section_characters) + ']+)$'
+    pattern = '^(' + re.escape(old_label) + ')\r?\n([' + re.escape(valid_section_characters) + ']+)\r?$'
     data, count = re.subn(pattern, replace_section, data, flags=re.MULTILINE)
     if count == 0:
         raise RuntimeError('Could not find section')


### PR DESCRIPTION
- Use shutil.which instead of manually finding git in path. This finds git.exe properly and is cleaner.
- Accept CR LF instead of just LF when trying to find version section