### PR TITLE
fixes overlaid develspace include dir order bug involving symlink

### DIFF
--- a/src/catkin_pkg/workspaces.py
+++ b/src/catkin_pkg/workspaces.py
@@ -75,13 +75,6 @@ def order_paths(paths_to_order, prefix_paths):
     :param paths_to_order: list of paths
     :param prefix_paths: list of prefixes, must not end with '/'
     """
-    def contains(prefix, path):
-        prefix = os.path.realpath(prefix)
-        path = os.path.realpath(path)
-        return (path == prefix
-                or path.startswith(prefix + os.sep)
-                or (os.altsep and path.startswith(prefix + os.altsep)))
-
     # the ordered paths contains a list for each prefix plus one more which contains paths which do not match one of the prefix_paths
     ordered_paths = [[] for _ in range(len(prefix_paths) + 1)]
 
@@ -89,13 +82,19 @@ def order_paths(paths_to_order, prefix_paths):
         # put each directory into the slot where it matches the prefix, or last otherwise
         index = 0
         for prefix in prefix_paths:
-            if contains(prefix, path):
+            if _is_equal_or_in_parents(prefix, path):
                 break
             index += 1
         ordered_paths[index].append(path)
 
     # flatten list of lists
     return [j for i in ordered_paths for j in i]
+
+
+def _is_equal_or_in_parents(dir_, path):
+    dir_ = os.path.normcase(os.path.realpath(dir_))
+    path = os.path.normcase(os.path.realpath(path))
+    return path == dir_ or path.startswith(dir_ + os.sep)
 
 
 def ensure_workspace_marker(base_path):

--- a/src/catkin_pkg/workspaces.py
+++ b/src/catkin_pkg/workspaces.py
@@ -75,6 +75,13 @@ def order_paths(paths_to_order, prefix_paths):
     :param paths_to_order: list of paths
     :param prefix_paths: list of prefixes, must not end with '/'
     """
+    def contains(prefix, path):
+        prefix = os.path.realpath(prefix)
+        path = os.path.realpath(path)
+        return (path == prefix
+                or path.startswith(prefix + os.sep)
+                or (os.altsep and path.startswith(prefix + os.altsep)))
+
     # the ordered paths contains a list for each prefix plus one more which contains paths which do not match one of the prefix_paths
     ordered_paths = [[] for _ in range(len(prefix_paths) + 1)]
 
@@ -82,7 +89,7 @@ def order_paths(paths_to_order, prefix_paths):
         # put each directory into the slot where it matches the prefix, or last otherwise
         index = 0
         for prefix in prefix_paths:
-            if path == prefix or path.startswith(prefix + os.sep) or (os.altsep and path.startswith(prefix + os.altsep)):
+            if contains(prefix, path):
                 break
             index += 1
         ordered_paths[index].append(path)

--- a/test/test_workspaces.py
+++ b/test/test_workspaces.py
@@ -2,7 +2,6 @@ from __future__ import print_function
 
 import os
 import shutil
-import sys
 import tempfile
 import unittest
 
@@ -43,14 +42,16 @@ class WorkspacesTest(unittest.TestCase):
         self.assertEqual(['baz', 'foo', 'bar'], order_paths(['bar', 'foo', 'baz'], ['baz', 'foo']))
         self.assertEqual(['foo' + os.sep + 'bim', 'bar'], order_paths(['bar', 'foo' + os.sep + 'bim'], ['foo']))
 
-    @unittest.skipUnless(sys.platform.startswith('linux'), 'requires Unix')
     def test_order_paths_with_symlink(self):
         try:
             root_dir = tempfile.mkdtemp()
             foo = os.path.join(root_dir, 'foo')
             foo_inc = os.path.join(root_dir, 'foo/include')
             foo_ln = os.path.join(root_dir, 'foo_symlink')
-            os.symlink(foo, foo_ln)
+            try:
+                os.symlink(foo, foo_ln)
+            except (AttributeError, OSError):
+                self.skipTest('requires symlink availability')
 
             self.assertEqual([foo, 'bar'], order_paths(['bar', foo], [foo_ln]))
             self.assertEqual([foo_ln, 'bar'], order_paths(['bar', foo_ln], [foo]))

--- a/test/test_workspaces.py
+++ b/test/test_workspaces.py
@@ -46,7 +46,7 @@ class WorkspacesTest(unittest.TestCase):
         root_dir = tempfile.mkdtemp()
         try:
             foo = os.path.join(root_dir, 'foo')
-            foo_inc = os.path.join(root_dir, 'foo/include')
+            foo_inc = os.path.join(foo, 'include')
             foo_ln = os.path.join(root_dir, 'foo_symlink')
             try:
                 os.symlink(foo, foo_ln)

--- a/test/test_workspaces.py
+++ b/test/test_workspaces.py
@@ -15,8 +15,8 @@ except ImportError as e:
 class WorkspacesTest(unittest.TestCase):
 
     def test_ensure_workspace_marker(self):
+        root_dir = tempfile.mkdtemp()
         try:
-            root_dir = tempfile.mkdtemp()
             ensure_workspace_marker(root_dir)
             self.assertTrue(os.path.exists(os.path.join(root_dir, CATKIN_WORKSPACE_MARKER_FILE)))
             # assert no exception on revisit
@@ -26,8 +26,8 @@ class WorkspacesTest(unittest.TestCase):
 
     def test_get_spaces(self):
         self.assertEqual([], get_spaces([]))
+        root_dir = tempfile.mkdtemp()
         try:
-            root_dir = tempfile.mkdtemp()
             self.assertEqual([], get_spaces([root_dir]))
             with open(os.path.join(root_dir, '.catkin'), 'a') as fhand:
                 fhand.write('')
@@ -43,8 +43,8 @@ class WorkspacesTest(unittest.TestCase):
         self.assertEqual(['foo' + os.sep + 'bim', 'bar'], order_paths(['bar', 'foo' + os.sep + 'bim'], ['foo']))
 
     def test_order_paths_with_symlink(self):
+        root_dir = tempfile.mkdtemp()
         try:
-            root_dir = tempfile.mkdtemp()
             foo = os.path.join(root_dir, 'foo')
             foo_inc = os.path.join(root_dir, 'foo/include')
             foo_ln = os.path.join(root_dir, 'foo_symlink')

--- a/test/test_workspaces.py
+++ b/test/test_workspaces.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 
 import os
 import shutil
+import sys
 import tempfile
 import unittest
 
@@ -41,3 +42,18 @@ class WorkspacesTest(unittest.TestCase):
         self.assertEqual(['foo', 'bar'], order_paths(['bar', 'foo'], ['foo']))
         self.assertEqual(['baz', 'foo', 'bar'], order_paths(['bar', 'foo', 'baz'], ['baz', 'foo']))
         self.assertEqual(['foo' + os.sep + 'bim', 'bar'], order_paths(['bar', 'foo' + os.sep + 'bim'], ['foo']))
+
+    @unittest.skipUnless(sys.platform.startswith('linux'), 'requires Unix')
+    def test_order_paths_with_symlink(self):
+        try:
+            root_dir = tempfile.mkdtemp()
+            foo = os.path.join(root_dir, 'foo')
+            foo_inc = os.path.join(root_dir, 'foo/include')
+            foo_ln = os.path.join(root_dir, 'foo_symlink')
+            os.symlink(foo, foo_ln)
+
+            self.assertEqual([foo, 'bar'], order_paths(['bar', foo], [foo_ln]))
+            self.assertEqual([foo_ln, 'bar'], order_paths(['bar', foo_ln], [foo]))
+            self.assertEqual([foo_inc, 'bar'], order_paths(['bar', foo_inc], [foo_ln]))
+        finally:
+            shutil.rmtree(root_dir)


### PR DESCRIPTION
This bug occurs when `setup.bash` of overlaid workspace is sourced through symlink path rather than absolute path. This commit resolves symlinks in `order_path` algorithm, allowing to detect that: `ws1/devel/include` starts with `ws1/devel_symlink` if `ws1/devel_symlink` is a symlink to `ws1/devel`.

original PR with problem description:
https://github.com/ros/catkin/pull/1017

original error reproduction:
https://github.com/aurzenligl/study/tree/master/ros-includedirorder