### PR TITLE
remove trusty, utopic, vivid, wily from list of suites

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -11,7 +11,7 @@ Depends3: python3-catkin-pkg-modules (>= 0.4.13), python3-dateutil, python3-docu
 Conflicts: catkin, python3-catkin-pkg
 Conflicts3: catkin, python-catkin-pkg
 Copyright-File: LICENSE
-Suite: trusty utopic vivid wily xenial yakkety zesty artful bionic cosmic disco eoan jessie stretch buster
+Suite: xenial yakkety zesty artful bionic cosmic disco eoan jessie stretch buster
 X-Python3-Version: >= 3.4
 Setup-Env-Vars: SKIP_PYTHON_MODULES=1
 
@@ -24,6 +24,6 @@ Conflicts3: catkin, python3-catkin-pkg (<< 0.3.0)
 Replaces: python-catkin-pkg (<< 0.3.0)
 Replaces3: python3-catkin-pkg (<< 0.3.0)
 Copyright-File: LICENSE
-Suite: trusty utopic vivid wily xenial yakkety zesty artful bionic cosmic disco eoan jessie stretch buster
+Suite: xenial yakkety zesty artful bionic cosmic disco eoan jessie stretch buster
 X-Python3-Version: >= 3.4
 Setup-Env-Vars: SKIP_PYTHON_SCRIPTS=1


### PR DESCRIPTION
Making the latest not-EOL LTS - Xenial - the lowest watermark.