### PR TITLE
Prevent Parallelization on Windows

### DIFF
--- a/src/catkin_pkg/packages.py
+++ b/src/catkin_pkg/packages.py
@@ -33,7 +33,8 @@
 """Library to find packages in the filesystem."""
 
 import multiprocessing
-import os, sys
+import os
+import sys
 
 from .package import _get_package_xml
 from .package import PACKAGE_MANIFEST_FILENAME

--- a/src/catkin_pkg/packages.py
+++ b/src/catkin_pkg/packages.py
@@ -135,7 +135,7 @@ def find_packages_allowing_duplicates(basepath, exclude_paths=None, exclude_subs
         return {}
 
     parallel = len(data) > 100
-    if sys.platform == "win32":
+    if sys.platform == 'win32':
         # Windows has path limitations which catkin overflows in nested environments
         # https://devblogs.microsoft.com/oldnewthing/20100203-00/?p=15083
         parallel = False

--- a/src/catkin_pkg/packages.py
+++ b/src/catkin_pkg/packages.py
@@ -33,7 +33,7 @@
 """Library to find packages in the filesystem."""
 
 import multiprocessing
-import os
+import os, sys
 
 from .package import _get_package_xml
 from .package import PACKAGE_MANIFEST_FILENAME
@@ -134,6 +134,11 @@ def find_packages_allowing_duplicates(basepath, exclude_paths=None, exclude_subs
         return {}
 
     parallel = len(data) > 100
+    if sys.platform == "win32":
+        # Windows has path limitations which catkin overflows in nested environments
+        # https://devblogs.microsoft.com/oldnewthing/20100203-00/?p=15083
+        parallel = False
+
     if parallel:
         try:
             pool = multiprocessing.Pool()


### PR DESCRIPTION
Windows has a total environment size limitation, which catkin can overflow during nested operations. This change prevents creating a nested catkin operation for exceptionally large work spaces.