### PR TITLE
Add a __repr__ for Dependency

### DIFF
--- a/src/catkin_pkg/package.py
+++ b/src/catkin_pkg/package.py
@@ -346,6 +346,14 @@ class Dependency(object):
     def __str__(self):
         return self.name
 
+    def __repr__(self):
+        kv = []
+        for slot in self.__slots__:
+            attr = getattr(self, slot, None)
+            if attr:
+                kv.append('{}={!r}'.format(slot, attr))
+        return '{}({})'.format(self.__class__.__name__, ', '.join(kv))
+
     def evaluate_condition(self, context):
         """
         Evaluate the condition.

--- a/src/catkin_pkg/package.py
+++ b/src/catkin_pkg/package.py
@@ -350,7 +350,7 @@ class Dependency(object):
         kv = []
         for slot in self.__slots__:
             attr = getattr(self, slot, None)
-            if attr:
+            if attr is not None:
                 kv.append('{}={!r}'.format(slot, attr))
         return '{}({})'.format(self.__class__.__name__, ', '.join(kv))
 

--- a/test/test_package.py
+++ b/test/test_package.py
@@ -118,6 +118,16 @@ class PackageTest(unittest.TestCase):
         dep = Dependency('foo', condition='foo <= bar or bar >= baz')
         self.assertFalse(dep.evaluate_condition({}))
 
+    def test_dependency_repr(self):
+        dep = Dependency('foo', condition='$foo == 2')
+        assert repr(dep) == "Dependency(name='foo', condition='$foo == 2')"
+        self.assertTrue(dep.evaluate_condition({'foo': 2}))
+        assert repr(dep) == "Dependency(name='foo', condition='$foo == 2', evaluated_condition=True)"
+
+        dep = Dependency('foo', condition='$foo == 2')
+        self.assertFalse(dep.evaluate_condition({'foo': 3}))
+        assert repr(dep) == "Dependency(name='foo', condition='$foo == 2', evaluated_condition=False)"
+
     def test_init_kwargs_string(self):
         pack = Package('foo',
                        name='bar',

--- a/test/test_package.py
+++ b/test/test_package.py
@@ -123,8 +123,6 @@ class PackageTest(unittest.TestCase):
         assert repr(dep) == "Dependency(name='foo', condition='$foo == 2')"
         self.assertTrue(dep.evaluate_condition({'foo': 2}))
         assert repr(dep) == "Dependency(name='foo', condition='$foo == 2', evaluated_condition=True)"
-
-        dep = Dependency('foo', condition='$foo == 2')
         self.assertFalse(dep.evaluate_condition({'foo': 3}))
         assert repr(dep) == "Dependency(name='foo', condition='$foo == 2', evaluated_condition=False)"
 


### PR DESCRIPTION
During debuging, I've made a simple `__repr__` for Dependency. It helped
me to visualize what was going on.

It prints dependencies like this:
```py
Dependency(name='foo', version_lt='3.0.0', condition='$ROS_VERSION == 2')
```