### PR TITLE
fix some escape sequences

### DIFF
--- a/src/catkin_pkg/changelog_generator.py
+++ b/src/catkin_pkg/changelog_generator.py
@@ -197,7 +197,7 @@ def get_version_section_match(data, version):
 def get_version_section_pattern(version):
     valid_section_characters = '!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~'
     headline = get_version_headline(version, None)
-    pattern = '^(' + re.escape(headline) + '( \([0-9 \-:|+]+\))?)\r?\n([' + re.escape(valid_section_characters) + ']+)\r?\n?$'
+    pattern = '^(' + re.escape(headline) + r'( \([0-9 \-:|+]+\))?)\r?\n([' + re.escape(valid_section_characters) + ']+)\r?\n?$'
     return pattern
 
 
@@ -277,7 +277,7 @@ def generate_version_content(log_entries, vcs_client=None, skip_contributors=Fal
 
 def escape_trailing_underscores(line):
     if line.endswith('_'):
-        line = line[:-1] + '\_'
+        line = line[:-1] + r'\_'
     # match words ending with an underscore which are not followed by another word
     # and insert a backslash before the underscore to escape it
     line = re.sub(r'(\w+)_([^\w])', '\\1\\_\\2', line)

--- a/src/catkin_pkg/changelog_generator_vcs.py
+++ b/src/catkin_pkg/changelog_generator_vcs.py
@@ -155,7 +155,7 @@ class GitClient(VcsClientBase):
         if result_tag['returncode']:
             raise RuntimeError('Could not fetch tags:\n%s' % result_tag['output'])
         # Parse a comma-separated list of refname decorators out of the log
-        decorations = ', '.join(re.findall('^[a-f0-9]+ \(([^)]*)\) .', result_tag['output'], re.MULTILINE)) + ','
+        decorations = ', '.join(re.findall(r'^[a-f0-9]+ \(([^)]*)\) .', result_tag['output'], re.MULTILINE)) + ','
         # Extract only refnames that are tags
         tag_names = re.findall('tag: ([^,]+)[,]', decorations)
 
@@ -240,7 +240,7 @@ class GitClient(VcsClientBase):
                 break
 
     def _replace_github_issue_references(self, line):
-        valid_name = '[\\w\._-]+'
+        valid_name = '[\\w._-]+'
         issue_pattern = '#(\\d+)'
 
         def replace_issue_number(match):

--- a/src/catkin_pkg/cmake.py
+++ b/src/catkin_pkg/cmake.py
@@ -77,4 +77,4 @@ def configure_string(template, environment):
     def substitute(match):
         var = match.group(0)[1:-1]
         return environment[var]
-    return re.sub('\@[a-zA-Z0-9_]+\@', substitute, template)
+    return re.sub('@[a-zA-Z0-9_]+@', substitute, template)

--- a/src/catkin_pkg/package.py
+++ b/src/catkin_pkg/package.py
@@ -237,12 +237,12 @@ class Package(object):
                     'Package name "%s" does not follow the naming conventions. It should start with '
                     'a lower case letter and only contain lower case letters, digits, underscores, and dashes.' % self.name)
 
-        version_regexp = '^[0-9]+\.[0-9]+\.[0-9]+$'
+        version_regexp = r'^[0-9]+\.[0-9]+\.[0-9]+$'
         if not self.version:
             errors.append('Package version must not be empty')
         elif not re.match(version_regexp, self.version):
             errors.append('Package version "%s" does not follow version conventions' % self.version)
-        elif not re.match('^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$', self.version):
+        elif not re.match(r'^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$', self.version):
             new_warnings.append('Package "%s" does not follow the version conventions. It should not contain leading zeros (unless the number is 0).' % self.name)
         if self.version_compatibility:
             if not re.match(version_regexp, self.version_compatibility):
@@ -433,7 +433,7 @@ class Person(object):
     def validate(self):
         if self.email is None:
             return
-        if not re.match('^[-a-zA-Z0-9_%+]+(\.[-a-zA-Z0-9_%+]+)*@[-a-zA-Z0-9%]+(\.[-a-zA-Z0-9%]+)*\.[a-zA-Z]{2,}$', self.email):
+        if not re.match(r'^[-a-zA-Z0-9_%+]+(\.[-a-zA-Z0-9_%+]+)*@[-a-zA-Z0-9%]+(\.[-a-zA-Z0-9%]+)*\.[a-zA-Z]{2,}$', self.email):
             raise InvalidPackage('Invalid email "%s" for person "%s"' % (self.email, self.name))
 
 
@@ -547,7 +547,7 @@ def has_ros_schema_reference_string(data):
         if child.nodeType == child.PROCESSING_INSTRUCTION_NODE:
             if child.target == 'xml-model':
                 # extract schema url from "xml-model" processing instruction
-                schema_url = re.search('href=\"([A-Za-z0-9\._/:]*)\"', child.data).group(1)
+                schema_url = re.search(r'href="([A-Za-z0-9\._/:]*)"', child.data).group(1)
                 if schema_url in PACKAGE_MANIFEST_SCHEMA_URLS:
                     return True
 

--- a/src/catkin_pkg/package_version.py
+++ b/src/catkin_pkg/package_version.py
@@ -53,7 +53,7 @@ def bump_version(version, bump='patch'):
     :raises ValueError: if the version string is not in the format x.y.z
     """
     # split the version number
-    match = re.match('^(\d+)\.(\d+)\.(\d+)$', version)
+    match = re.match(r'^(\d+)\.(\d+)\.(\d+)$', version)
     if match is None:
         raise ValueError('Invalid version string, must be int.int.int: "%s"' % version)
     new_version = match.groups()
@@ -78,7 +78,7 @@ def _replace_version(package_str, new_version):
     :raises RuntimeError:
     """
     # try to replace contens
-    new_package_str, number_of_subs = re.subn('<version([^<>]*)>[^<>]*</version>', '<version\g<1>>%s</version>' % new_version, package_str)
+    new_package_str, number_of_subs = re.subn('<version([^<>]*)>[^<>]*</version>', r'<version\g<1>>%s</version>' % new_version, package_str)
     if number_of_subs != 1:
         raise RuntimeError('Illegal number of version tags: %s' % (number_of_subs))
     return new_package_str


### PR DESCRIPTION
Escaping in regexes has not been done correctly in a number of places, which recent Python versions warn about.