### PR TITLE
Add a Suite3 option with Ubuntu Focal.

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -12,6 +12,7 @@ Conflicts: catkin, python3-catkin-pkg
 Conflicts3: catkin, python-catkin-pkg
 Copyright-File: LICENSE
 Suite: xenial yakkety zesty artful bionic cosmic disco eoan jessie stretch buster
+Suite3: xenial yakkety zesty artful bionic cosmic disco eoan focal jessie stretch buster
 X-Python3-Version: >= 3.4
 Setup-Env-Vars: SKIP_PYTHON_MODULES=1
 
@@ -25,5 +26,6 @@ Replaces: python-catkin-pkg (<< 0.3.0)
 Replaces3: python3-catkin-pkg (<< 0.3.0)
 Copyright-File: LICENSE
 Suite: xenial yakkety zesty artful bionic cosmic disco eoan jessie stretch buster
+Suite3: xenial yakkety zesty artful bionic cosmic disco eoan focal jessie stretch buster
 X-Python3-Version: >= 3.4
 Setup-Env-Vars: SKIP_PYTHON_SCRIPTS=1


### PR DESCRIPTION
This configuration option requires two recent changes in stdeb and
ros_release_python:
* https://github.com/astraw/stdeb/pull/147 for Suite3 support from stdeb (not yet merged or released)
* https://github.com/ros-infrastructure/ros_release_python/pull/33 for `--include` support on the current bootstrap repository.

The option allows a different set of suites to be set for Python 3
releases allowing us to forestall releasing Python2 versions of these
packages for platforms where we don't plan to support Python 2.