### PR TITLE
Fix crash with pyparsing 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 install_requires = [
     'docutils',
     'python-dateutil',
-    'pyparsing>=2',
+    'pyparsing>=1.5.7',
 ]
 
 # argparse is part of the standard library since Python 2.7

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 install_requires = [
     'docutils',
     'python-dateutil',
-    'pyparsing',
+    'pyparsing>=2',
 ]
 
 # argparse is part of the standard library since Python 2.7

--- a/src/catkin_pkg/condition.py
+++ b/src/catkin_pkg/condition.py
@@ -41,7 +41,7 @@ def _get_condition_expression():
         value = pp.Word(pp.alphanums + '_-')
         comparison_term = identifier | value
         condition = pp.Group(comparison_term + operator + comparison_term)
-        _condition_expression = pp.operatorPrecedence(
+        _condition_expression = pp.infixNotation(
             condition, [
                 ('and', 2, pp.opAssoc.LEFT, ),
                 ('or', 2, pp.opAssoc.LEFT, ),


### PR DESCRIPTION
pyparsing.operatorPrecedence was deprecated in pyparsing 1.5.7 and removed in pyparsing 3

https://github.com/pyparsing/pyparsing/blob/master/CHANGES
```
colcon build --packages-up-to rmw_cyclonedds_cpp
[8.139s] ERROR:colcon.colcon_core.package_identification:Exception in package identification extension 'ros.bazel' in '/opt/ros/master/src/osrf/osrf_pycommon': module 'pyparsing' has no attribute 'operatorPrecedence'
Traceback (most recent call last):
  File "/Users/dan/Documents/colcon_ws/src/colcon-core/colcon_core/package_identification/__init__.py", line 143, in _identify
    retval = extension.identify(_reused_descriptor_instance)
  File "/Users/dan/Documents/colcon_ws/src/colcon-ros-bazel/colcon_ros_bazel/package_identification/ros_bazel.py", line 39, in identify
    ros_extension.identify(tmp_desc)
  File "/Users/dan/Documents/colcon_ws/src/colcon-ros/colcon_ros/package_identification/ros.py", line 59, in identify
    pkg, build_type = get_package_with_build_type(str(desc.path))
  File "/Users/dan/Documents/colcon_ws/src/colcon-ros/colcon_ros/package_identification/ros.py", line 163, in get_package_with_build_type
    pkg = _get_package(path)
  File "/Users/dan/Documents/colcon_ws/src/colcon-ros/colcon_ros/package_identification/ros.py", line 195, in _get_package
    pkg.evaluate_conditions(os.environ)
  File "/usr/local/Cellar/python/HEAD-29356e0/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/catkin_pkg/package.py", line 212, in evaluate_conditions
    conditional.evaluate_condition(context)
  File "/usr/local/Cellar/python/HEAD-29356e0/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/catkin_pkg/package.py", line 369, in evaluate_condition
    self.evaluated_condition = evaluate_condition(self.condition, context)
  File "/usr/local/Cellar/python/HEAD-29356e0/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/catkin_pkg/condition.py", line 23, in evaluate_condition
    expr = _get_condition_expression()
  File "/usr/local/Cellar/python/HEAD-29356e0/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/catkin_pkg/condition.py", line 44, in _get_condition_expression
    _condition_expression = pp.operatorPrecedence(
AttributeError: module 'pyparsing' has no attribute 'operatorPrecedence'

[8.147s] ERROR:colcon.colcon_core.package_identification:Exception in package identification extension 'ros' in '/opt/ros/master/src/osrf/osrf_pycommon': module 'pyparsing' has no attribute 'operatorPrecedence'
Traceback (most recent call last):
  File "/Users/dan/Documents/colcon_ws/src/colcon-core/colcon_core/package_identification/__init__.py", line 143, in _identify
    retval = extension.identify(_reused_descriptor_instance)
  File "/Users/dan/Documents/colcon_ws/src/colcon-ros/colcon_ros/package_identification/ros.py", line 59, in identify
    pkg, build_type = get_package_with_build_type(str(desc.path))
  File "/Users/dan/Documents/colcon_ws/src/colcon-ros/colcon_ros/package_identification/ros.py", line 163, in get_package_with_build_type
    pkg = _get_package(path)
  File "/Users/dan/Documents/colcon_ws/src/colcon-ros/colcon_ros/package_identification/ros.py", line 195, in _get_package
    pkg.evaluate_conditions(os.environ)
  File "/usr/local/Cellar/python/HEAD-29356e0/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/catkin_pkg/package.py", line 212, in evaluate_conditions
    conditional.evaluate_condition(context)
  File "/usr/local/Cellar/python/HEAD-29356e0/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/catkin_pkg/package.py", line 369, in evaluate_condition
    self.evaluated_condition = evaluate_condition(self.condition, context)
  File "/usr/local/Cellar/python/HEAD-29356e0/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/catkin_pkg/condition.py", line 23, in evaluate_condition
    expr = _get_condition_expression()
  File "/usr/local/Cellar/python/HEAD-29356e0/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/catkin_pkg/condition.py", line 44, in _get_condition_expression
    _condition_expression = pp.operatorPrecedence(
AttributeError: module 'pyparsing' has no attribute 'operatorPrecedence'
```
