### PR TITLE
use parse actions to evaluate conditions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
-os: linux
 dist: xenial
+sudo: false
 python:
   - "2.7"
   - "3.4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
+os: linux
 dist: xenial
-sudo: false
 python:
   - "2.7"
   - "3.4"

--- a/src/catkin_pkg/condition.py
+++ b/src/catkin_pkg/condition.py
@@ -14,64 +14,38 @@
 
 import operator
 
-import pyparsing
+import pyparsing as pp
 
 
-def evaluate_condition(condition, context):
-    if condition is None:
-        return True
-    expr = _get_condition_expression()
-    try:
-        parse_results = expr.parseString(condition, parseAll=True)
-    except pyparsing.ParseException as e:
-        raise ValueError(
-            "condition '%s' failed to parse: %s" % (condition, e))
-    return _evaluate(parse_results.asList()[0], context)
+class Condition:
+
+    def __init__(self, t):
+        self.value = t[0]
+
+    def __call__(self, context):
+        return self.value[1](self.value[0], self.value[2], context)
+
+    def __str__(self):
+        return ' '.join(map(str, self.value))
+
+    __repr__ = __str__
 
 
-_condition_expression = None
+class Identifier:
+
+    def __init__(self, t):
+        self.value = t[0]
+
+    def __call__(self, context):
+        return str(context.get(self.value[1:], ''))
+
+    def __str__(self):
+        return self.value
+
+    __repr__ = __str__
 
 
-def _get_condition_expression():
-    global _condition_expression
-    if not _condition_expression:
-        pp = pyparsing
-        operator = pp.Regex('==|!=|>=|>|<=|<').setName('operator')
-        identifier = pp.Word('$', pp.alphanums + '_', min=2)
-        value = pp.Word(pp.alphanums + '_-')
-        comparison_term = identifier | value
-        condition = pp.Group(comparison_term + operator + comparison_term)
-        _condition_expression = pp.operatorPrecedence(
-            condition, [
-                ('and', 2, pp.opAssoc.LEFT, ),
-                ('or', 2, pp.opAssoc.LEFT, ),
-            ])
-    return _condition_expression
-
-
-def _evaluate(parse_results, context):
-    if not isinstance(parse_results, list):
-        if parse_results.startswith('$'):
-            # get variable from context
-            return str(context.get(parse_results[1:], ''))
-        # return literal value
-        return parse_results
-
-    # recursion
-    assert len(parse_results) >= 3 and len(parse_results) % 2 == 1
-
-    # handle logical operators
-    if parse_results[1] == 'and':
-        return _evaluate(parse_results[0], context) and \
-            _evaluate(parse_results[2] if len(parse_results) == 3
-                      else parse_results[2:], context)
-    if parse_results[1] == 'or':
-        return _evaluate(parse_results[0], context) or \
-            _evaluate(parse_results[2] if len(parse_results) == 3
-                      else parse_results[2:], context)
-
-    # handle comparison operators
-    assert len(parse_results) == 3
+class Operator:
     operators = {
         '==': operator.eq,
         '!=': operator.ne,
@@ -80,7 +54,94 @@ def _evaluate(parse_results, context):
         '>=': operator.ge,
         '>': operator.gt,
     }
-    assert parse_results[1] in operators.keys()
-    return operators[parse_results[1]](
-        _evaluate(parse_results[0], context),
-        _evaluate(parse_results[2], context))
+
+    def __init__(self, t):
+        self.value = t[0]
+
+    def __call__(self, arg1, arg2, context):
+        assert self.value in self.operators
+        return self.operators[self.value](arg1(context), arg2(context))
+
+    def __str__(self):
+        return self.value
+
+    __repr__ = __str__
+
+
+class Value:
+
+    def __init__(self, t):
+        self.value = t[0]
+
+    def __call__(self, context):
+        return self.value
+
+    def __str__(self):
+        return self.value
+
+    __repr__ = __str__
+
+
+class BinOp:
+
+    def __init__(self, t):
+        self.args = t[0][0::2]
+
+    def __call__(self, context):
+        return self.evalop(a(context) for a in self.args)
+
+    def __str__(self):
+        sep = ' %s  ' % self.reprsymbol
+        return '(' + sep.join(map(str, self.args)) + ')'
+
+    __repr__ = __str__
+
+
+class And(BinOp):
+    reprsymbol = 'and'
+    evalop = all
+
+
+class Or(BinOp):
+    reprsymbol = 'or'
+    evalop = any
+
+
+_condition_expression = None
+
+
+def _get_condition_expression():
+    global _condition_expression
+    if not _condition_expression:
+        operator = pp.Regex('==|!=|>=|>|<=|<').setName('operator')
+        operator.setParseAction(Operator)
+
+        identifier = pp.Word('$', pp.alphanums + '_', min=2).setName('identifier')
+        identifier.setParseAction(Identifier)
+
+        value = pp.Word(pp.alphanums + '_-').setName('value')
+        value.setParseAction(Value)
+
+        comparison_term = identifier | value
+
+        condition = pp.Group(comparison_term + operator + comparison_term).setName('condition')
+        condition.setParseAction(Condition)
+
+        _condition_expression = pp.operatorPrecedence(
+            condition, [
+                ('and', 2, pp.opAssoc.LEFT, And),
+                ('or', 2, pp.opAssoc.LEFT, Or),
+            ])
+    return _condition_expression
+
+
+def evaluate_condition(condition, context):
+    if condition is None:
+        return True
+    expr = _get_condition_expression()
+    try:
+        parse_results = expr.parseString(condition, parseAll=True)
+    except pp.ParseException as e:
+        raise ValueError(
+            "condition '%s' failed to parse: %s" % (condition, e))
+    return parse_results[0](context)

--- a/src/catkin_pkg/condition.py
+++ b/src/catkin_pkg/condition.py
@@ -17,6 +17,18 @@ import operator
 import pyparsing as pp
 
 
+def evaluate_condition(condition, context):
+    if condition is None:
+        return True
+    expr = _get_condition_expression()
+    try:
+        parse_results = expr.parseString(condition, parseAll=True)
+    except pp.ParseException as e:
+        raise ValueError(
+            "condition '%s' failed to parse: %s" % (condition, e))
+    return parse_results[0](context)
+
+
 class Condition:
 
     def __init__(self, t):
@@ -133,15 +145,3 @@ def _get_condition_expression():
                 ('or', 2, pp.opAssoc.LEFT, Or),
             ])
     return _condition_expression
-
-
-def evaluate_condition(condition, context):
-    if condition is None:
-        return True
-    expr = _get_condition_expression()
-    try:
-        parse_results = expr.parseString(condition, parseAll=True)
-    except pp.ParseException as e:
-        raise ValueError(
-            "condition '%s' failed to parse: %s" % (condition, e))
-    return parse_results[0](context)

--- a/src/catkin_pkg/condition.py
+++ b/src/catkin_pkg/condition.py
@@ -36,28 +36,28 @@ def _get_condition_expression():
     global _condition_expression
     if not _condition_expression:
         operator = pp.Regex('==|!=|>=|>|<=|<').setName('operator')
-        operator.setParseAction(Operator)
+        operator.setParseAction(_Operator)
 
         identifier = pp.Word('$', pp.alphanums + '_', min=2).setName('identifier')
-        identifier.setParseAction(Identifier)
+        identifier.setParseAction(_Identifier)
 
         value = pp.Word(pp.alphanums + '_-').setName('value')
-        value.setParseAction(Value)
+        value.setParseAction(_Value)
 
         comparison_term = identifier | value
 
         condition = pp.Group(comparison_term + operator + comparison_term).setName('condition')
-        condition.setParseAction(Condition)
+        condition.setParseAction(_Condition)
 
         _condition_expression = pp.infixNotation(
             condition, [
-                ('and', 2, pp.opAssoc.LEFT, And),
-                ('or', 2, pp.opAssoc.LEFT, Or),
+                ('and', 2, pp.opAssoc.LEFT, _And),
+                ('or', 2, pp.opAssoc.LEFT, _Or),
             ])
     return _condition_expression
 
 
-class Operator:
+class _Operator:
     operators = {
         '==': operator.eq,
         '!=': operator.ne,
@@ -80,7 +80,7 @@ class Operator:
     __repr__ = __str__
 
 
-class Identifier:
+class _Identifier:
 
     def __init__(self, t):
         self.value = t[0]
@@ -94,7 +94,7 @@ class Identifier:
     __repr__ = __str__
 
 
-class Value:
+class _Value:
 
     def __init__(self, t):
         self.value = t[0]
@@ -108,7 +108,7 @@ class Value:
     __repr__ = __str__
 
 
-class Condition:
+class _Condition:
 
     def __init__(self, t):
         self.value = t[0]
@@ -122,7 +122,7 @@ class Condition:
     __repr__ = __str__
 
 
-class BinOp:
+class _BinOp:
 
     def __init__(self, t):
         self.args = t[0][0::2]
@@ -137,11 +137,11 @@ class BinOp:
     __repr__ = __str__
 
 
-class And(BinOp):
+class _And(_BinOp):
     reprsymbol = 'and'
     evalop = all
 
 
-class Or(BinOp):
+class _Or(_BinOp):
     reprsymbol = 'or'
     evalop = any


### PR DESCRIPTION
Inspired by https://github.com/pyparsing/pyparsing/blob/master/examples/simpleBool.py
With the use of ParseActions, the result are specific classes in which
better use is made of the results of the operatorPrecedence.

I wanted to use `bool` with an extra argument, but that isn't allowed, therefore I chose to implement `__call__` for all the classes.

Fixes #277, #281, improvement of #279 