### PR TITLE
bump min CMake version to avoid CMP0048 warning

### DIFF
--- a/src/catkin_pkg/templates/CMakeLists.txt.in
+++ b/src/catkin_pkg/templates/CMakeLists.txt.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(@name)
 
 ## Compile as C++11, supported in ROS Kinetic and newer


### PR DESCRIPTION
So that newly created packages dont run into https://github.com/ros/catkin/pull/1052