### PR TITLE
Restore compatibility with pyparsing < 1.5.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 install_requires = [
     'docutils',
     'python-dateutil',
-    'pyparsing>=1.5.7',
+    'pyparsing',
 ]
 
 # argparse is part of the standard library since Python 2.7

--- a/src/catkin_pkg/condition.py
+++ b/src/catkin_pkg/condition.py
@@ -16,6 +16,12 @@ import operator
 
 import pyparsing as pp
 
+# operatorPrecedence renamed to infixNotation in 1.5.7
+try:
+    from pyparsing import infixNotation as infixNotation
+except ImportError:
+    from pyparsing import operatorPrecedence as infixNotation
+
 
 def evaluate_condition(condition, context):
     if condition is None:
@@ -49,7 +55,7 @@ def _get_condition_expression():
         condition = pp.Group(comparison_term + operator + comparison_term).setName('condition')
         condition.setParseAction(_Condition)
 
-        _condition_expression = pp.infixNotation(
+        _condition_expression = infixNotation(
             condition, [
                 ('and', 2, pp.opAssoc.LEFT, _And),
                 ('or', 2, pp.opAssoc.LEFT, _Or),

--- a/src/catkin_pkg/condition.py
+++ b/src/catkin_pkg/condition.py
@@ -18,7 +18,7 @@ import pyparsing as pp
 
 # operatorPrecedence renamed to infixNotation in 1.5.7
 try:
-    from pyparsing import infixNotation as infixNotation
+    from pyparsing import infixNotation
 except ImportError:
     from pyparsing import operatorPrecedence as infixNotation
 


### PR DESCRIPTION
RHEL 7 currently has pyparsing 1.5.6.

Compatibility was regressed by #282