### PR TITLE
support quoted values in conditions

### DIFF
--- a/src/catkin_pkg/condition.py
+++ b/src/catkin_pkg/condition.py
@@ -50,7 +50,15 @@ def _get_condition_expression():
         value = pp.Word(pp.alphanums + '_-').setName('value')
         value.setParseAction(_Value)
 
-        comparison_term = identifier | value
+        double_quoted_value = pp.QuotedString('"').setName(
+            'double_quoted_value')
+        double_quoted_value.setParseAction(_Value)
+        single_quoted_value = pp.QuotedString("'").setName(
+            'single_quoted_value')
+        single_quoted_value.setParseAction(_Value)
+
+        comparison_term = identifier | value | double_quoted_value | \
+            single_quoted_value
 
         condition = pp.Group(comparison_term + operator + comparison_term).setName('condition')
         condition.setParseAction(_Condition)

--- a/test/test_package.py
+++ b/test/test_package.py
@@ -121,6 +121,22 @@ class PackageTest(unittest.TestCase):
         dep = Dependency('foo', condition='foo <= bar or bar >= baz')
         self.assertFalse(dep.evaluate_condition({}))
 
+        dep = Dependency('foo', condition='$foo == ""')
+        self.assertTrue(dep.evaluate_condition({}))
+        self.assertFalse(dep.evaluate_condition({'foo': 'foo'}))
+
+        dep = Dependency('foo', condition='$foo == "foo \' bar"')
+        self.assertTrue(dep.evaluate_condition({'foo': "foo ' bar"}))
+        self.assertFalse(dep.evaluate_condition({}))
+
+        dep = Dependency('foo', condition="$foo == ''")
+        self.assertTrue(dep.evaluate_condition({}))
+        self.assertFalse(dep.evaluate_condition({'foo': 'foo'}))
+
+        dep = Dependency('foo', condition="$foo == 'foo \" bar'")
+        self.assertTrue(dep.evaluate_condition({'foo': 'foo " bar'}))
+        self.assertFalse(dep.evaluate_condition({}))
+
         # Testing for more than 1 conditions
         dep = Dependency('foo', condition='foo > bar and bar < baz and foo > bar')
         self.assertTrue(dep.evaluate_condition({}))


### PR DESCRIPTION
The patch enables to express a condition like this: `$FOO == ""`.

This requires REP 149 to be updated (or if that is not feasible a new REP / format version). **Update:** see ros-infrastructure/rep#288.