### PR TITLE
[changelog] An option to show only merge commits.

### DIFF
--- a/src/catkin_pkg/changelog_generator.py
+++ b/src/catkin_pkg/changelog_generator.py
@@ -48,7 +48,7 @@ from catkin_pkg.changelog_generator_vcs import Tag
 FORTHCOMING_LABEL = 'Forthcoming'
 
 
-def get_all_changes(vcs_client, skip_merges=False):
+def get_all_changes(vcs_client, skip_merges=False, only_merges=False):
     tags = _get_version_tags(vcs_client)
 
     # query all log entries per tag range
@@ -56,16 +56,16 @@ def get_all_changes(vcs_client, skip_merges=False):
     previous_tag = Tag(None)
     for tag in sorted_tags(tags):
         log_entries = vcs_client.get_log_entries(
-            from_tag=previous_tag.name, to_tag=tag.name, skip_merges=skip_merges)
+            from_tag=previous_tag.name, to_tag=tag.name, skip_merges=skip_merges, only_merges=only_merges)
         tag2log_entries[previous_tag] = log_entries
         previous_tag = tag
     log_entries = vcs_client.get_log_entries(
-        from_tag=previous_tag.name, to_tag=None, skip_merges=skip_merges)
+        from_tag=previous_tag.name, to_tag=None, skip_merges=skip_merges, only_merges=only_merges)
     tag2log_entries[previous_tag] = log_entries
     return tag2log_entries
 
 
-def get_forthcoming_changes(vcs_client, skip_merges=False):
+def get_forthcoming_changes(vcs_client, skip_merges=False, only_merges=False):
     tags = _get_version_tags(vcs_client)
     latest_tag_name = _get_latest_version_tag_name(vcs_client)
 
@@ -79,7 +79,7 @@ def get_forthcoming_changes(vcs_client, skip_merges=False):
         # ignore non-forthcoming log entries but keep version to identify injection point of forthcoming
         tag2log_entries[tag] = None
     log_entries = vcs_client.get_log_entries(
-        from_tag=from_tag.name, to_tag=to_tag.name, skip_merges=skip_merges)
+        from_tag=from_tag.name, to_tag=to_tag.name, skip_merges=skip_merges, only_merges=only_merges)
     tag2log_entries[from_tag] = log_entries
     return tag2log_entries
 

--- a/src/catkin_pkg/changelog_generator_vcs.py
+++ b/src/catkin_pkg/changelog_generator_vcs.py
@@ -88,7 +88,7 @@ class VcsClientBase(object):
     def get_latest_tag_name(self):
         raise NotImplementedError()
 
-    def get_log_entries(self, from_tag, to_tag, skip_merges=False):
+    def get_log_entries(self, from_tag, to_tag, skip_merges=False, only_merges=False):
         raise NotImplementedError()
 
     def replace_repository_references(self, line):
@@ -179,14 +179,18 @@ class GitClient(VcsClientBase):
         tag_name = result_describe['output']
         return tag_name
 
-    def get_log_entries(self, from_tag, to_tag, skip_merges=False):
+    def get_log_entries(self, from_tag, to_tag, skip_merges=False, only_merges=False):
         # query all hashes in the range
         cmd = [self._executable, 'log']
         if from_tag or to_tag:
             cmd.append('%s%s' % ('%s..' % to_tag if to_tag else '', from_tag if from_tag else ''))
         cmd.append('--format=format:%H')
+        if skip_merges and only_merges:
+            raise RuntimeError('Both "skip_merges" and "only_merges" are set to True, which contradicts.')
         if skip_merges:
             cmd.append('--no-merges')
+        if only_merges:
+            cmd.append('--merges')
         result = self._run_command(cmd)
         if result['returncode']:
             raise RuntimeError('Could not fetch commit hashes:\n%s' % result['output'])
@@ -348,7 +352,7 @@ class HgClient(VcsClientBase):
             raise RuntimeError('Could not find latest tagn')
         return tag_name
 
-    def get_log_entries(self, from_tag, to_tag, skip_merges=False):
+    def get_log_entries(self, from_tag, to_tag, skip_merges=False, only_merges=False):
         # query all hashes in the range
         # ascending chronological order since than it is easier to handle empty tag names
         revrange = '%s:%s' % ((to_tag if to_tag else ''), (from_tag if from_tag else 'tip'))

--- a/src/catkin_pkg/cli/generate_changelog.py
+++ b/src/catkin_pkg/cli/generate_changelog.py
@@ -40,10 +40,11 @@ def prompt_continue(msg, default):
 
 def main(sysargs=None):
     parser = argparse.ArgumentParser(description='Generate a REP-0132 %s' % CHANGELOG_FILENAME)
+    group_merge = parser.add_mutually_exclusive_group()
     parser.add_argument(
         '-a', '--all', action='store_true', default=False,
         help='Generate changelog for all versions instead of only the forthcoming one (only supported when no changelog file exists yet)')
-    parser.add_argument(
+    group_merge.add_argument(
         '--only-merges', action='store_true', default=False,
         help='Only add merge commits to the changelog')
     parser.add_argument(
@@ -52,7 +53,7 @@ def main(sysargs=None):
     parser.add_argument(
         '--skip-contributors', action='store_true', default=False,
         help='Skip adding the list of contributors to the changelog')
-    parser.add_argument(
+    group_merge.add_argument(
         '--skip-merges', action='store_true', default=False,
         help='Skip adding merge commits to the changelog')
     parser.add_argument(

--- a/src/catkin_pkg/cli/generate_changelog.py
+++ b/src/catkin_pkg/cli/generate_changelog.py
@@ -44,6 +44,9 @@ def main(sysargs=None):
         '-a', '--all', action='store_true', default=False,
         help='Generate changelog for all versions instead of only the forthcoming one (only supported when no changelog file exists yet)')
     parser.add_argument(
+        '--only-merges', action='store_true', default=False,
+        help='Only add merge commits to the changelog')
+    parser.add_argument(
         '--print-root', action='store_true', default=False,
         help='Output changelog content to the console as if there would be only one package in the root of the repository')
     parser.add_argument(
@@ -66,11 +69,11 @@ def main(sysargs=None):
         # printing status messages to stderr to allow piping the changelog to a file
         if args.all:
             print('Querying all tags and commit information...', file=sys.stderr)
-            tag2log_entries = get_all_changes(vcs_client, skip_merges=args.skip_merges)
+            tag2log_entries = get_all_changes(vcs_client, skip_merges=args.skip_merges, only_merges=args.only_merges)
             print('Generating changelog output with all versions...', file=sys.stderr)
         else:
             print('Querying commit information since latest tag...', file=sys.stderr)
-            tag2log_entries = get_forthcoming_changes(vcs_client, skip_merges=args.skip_merges)
+            tag2log_entries = get_forthcoming_changes(vcs_client, skip_merges=args.skip_merges, only_merges=args.only_merges)
             print('Generating changelog files with forthcoming version...', file=sys.stderr)
         print('', file=sys.stderr)
         data = generate_changelog_file('repository-level', tag2log_entries, vcs_client=vcs_client)
@@ -106,12 +109,12 @@ def main(sysargs=None):
 
     if args.all:
         print('Querying all tags and commit information...')
-        tag2log_entries = get_all_changes(vcs_client, skip_merges=args.skip_merges)
+        tag2log_entries = get_all_changes(vcs_client, skip_merges=args.skip_merges, only_merges=args.only_merges)
         print('Generating changelog files with all versions...')
         generate_changelogs(base_path, packages, tag2log_entries, logger=logging, vcs_client=vcs_client, skip_contributors=args.skip_contributors)
     else:
         print('Querying commit information since latest tag...')
-        tag2log_entries = get_forthcoming_changes(vcs_client, skip_merges=args.skip_merges)
+        tag2log_entries = get_forthcoming_changes(vcs_client, skip_merges=args.skip_merges, only_merges=args.only_merges)
         # separate packages with/without a changelog file
         packages_without = {pkg_path: package for pkg_path, package in packages.items() if package.name in missing_changelogs}
         if packages_without:


### PR DESCRIPTION
# Problem this PR aims to solve

Too many items in the changelog: `catkin_generat_changelog` certainly helps making the complete list of changes. Problem is listing commits description of all commits isn't helpful in some/many cases unless commit history is well-made with very meaningful chunks with descriptive commit message.  Even so, commit history may be more for developers, so in product development where non-developers need changelog, only top-level description of the changes (Bugfix? New capability? etc.) are needed and figuring out top-level change from the list of commit messages is difficult (particularly when the maintainer who's making the changelog is not the one that made or reviewed all the commits).

# Solution taken in this PR

- Add an option to show only the commits made by MR/PRs.
   - List the messages from only merge commits when they are present, in the changelog.
      - catkin_generate_changelog can list merge commits (I confirmed for Git{Hub, Lab}), with the link to a merge/pull request if available (example posted below). This makes easier for a maintainer to describe the changes, and with a link it's easier to track down the change on the online repository.
         ```
         Merge branch 'branch-a' into 'develop'
       
          disabled X by default
       
          See merge request org/org-sub/org-sub-sub/repo!97
         ```

## Open question
- Unit test missing for this new option.
   - The new option involves `git` to run, and I haven't been able to think of a way to test that involves `git` operation, without cloning an external repo during the test. Looked into the test folder and there's no test cases yet that test vcs operation. That said, if unit test is absolutely needed, I appreciate if someone can provide ideas how to achieve it.

# Example output
```
# catkin_generate_changelog  --only-merges                                                                                                                                                                                                         
Querying commit information since latest tag...
Updating forthcoming section of changelog files...
- updating 'b_data_collection/CHANGELOG.rst'
- updating 'b_sensor/b_asus/CHANGELOG.rst'
:
Done.

# git diff

:
 
diff --git a/b_support/CHANGELOG.rst b/b_support/CHANGELOG.rst
index ca6571b..6663858 100644
--- a/b_support/CHANGELOG.rst
+++ b/b_support/CHANGELOG.rst
@@ -2,6 +2,22 @@
 Changelog for package b_support
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Merge branch 'feature-enable-redundancy' into 'develop'
+  Feature enable redundancy
+  See merge request `plusone-robotics/b/b_tools!265 <https://gitlab.com/plusone-robotics/b/b_tools/-/merge_requests/265>`_
+* Merge branch 'feature-standardize-background-init-wait' into 'develop'
+  Feature standardize background init wait
+  See merge request `plusone-robotics/b/b_tools!263 <https://gitlab.com/plusone-robotics/b/b_tools/-/merge_requests/263>`_
+* Merge branch 'synch-master-dev-post350' into 'develop'
+  Synch master -> develop post 3.5.0
+  See merge request `plusone-robotics/b/b_tools!262 <https://gitlab.com/plusone-robotics/b/b_tools/-/merge_requests/262>`_
+* Merge branch 'release_3.5.0' into 'master'
+  Release 3.5.0
+  See merge request `plusone-robotics/b/b_tools!261 <https://gitlab.com/plusone-robotics/b/b_tools/-/merge_requests/261>`_
+
```
Without this option,
```
# git stash
# catkin_generate_changelog
# git diff
:
diff --git a/b_support/CHANGELOG.rst b/b_support/CHANGELOG.rst
index ca6571b..afab428 100644
--- a/b_support/CHANGELOG.rst
+++ b/b_support/CHANGELOG.rst
@@ -2,6 +2,28 @@
 Changelog for package b_support
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Merge branch 'feature-enable-redundancy' into 'develop'
+  Feature enable redundancy
+  See merge request `plusone-robotics/b/b_tools!265 <https://gitlab.com/plusone-robotics/b/b_tools/-/merge_requests/265>`_
+* Update b_trigger_pick.yaml
+* Update b_trigger_pick.yaml
+* Update b_trigger_pick.yaml
+* Merge branch 'feature-standardize-background-init-wait' into 'develop'
+  Feature standardize background init wait
+  See merge request `plusone-robotics/b/b_tools!263 <https://gitlab.com/plusone-robotics/b/b_tools/-/merge_requests/263>`_
+* Update ba_loa.yaml
+* Update ba_loa.yaml
+* Update ba_loa_place.yaml
+* Merge branch 'synch-master-dev-post350' into 'develop'
+  Synch master -> develop post 3.5.0
+  See merge request `plusone-robotics/b/b_tools!262 <https://gitlab.com/plusone-robotics/b/b_tools/-/merge_requests/262>`_
+* Merge branch 'release_3.5.0' into 'master'
+  Release 3.5.0
+  See merge request `plusone-robotics/b/b_tools!261 <https://gitlab.com/plusone-robotics/b/b_tools/-/merge_requests/261>`_
```
CC @aaronplusone 