### PR TITLE
Optionally don't put comments in generated files

### DIFF
--- a/src/catkin_pkg/cli/create_pkg.py
+++ b/src/catkin_pkg/cli/create_pkg.py
@@ -42,6 +42,9 @@ def main(argv=sys.argv[1:], parent_path=os.getcwd()):
     parser.add_argument('-m', '--maintainer',
                         action='append',
                         help='A single maintainer, may be used multiple times')
+    parser.add_argument('-n', '--no_comments',
+                        action='store_true',
+                        help="Don't put comments in package.xml or CMakeLists.txt")
     rosdistro_name = os.environ['ROS_DISTRO'] if 'ROS_DISTRO' in os.environ else None
     parser.add_argument('--rosdistro', required=rosdistro_name is None, default=rosdistro_name, help='The ROS distro (default: environment variable ROS_DISTRO if defined)')
 
@@ -64,7 +67,8 @@ def main(argv=sys.argv[1:], parent_path=os.getcwd()):
                              package_template=package_template,
                              rosdistro=args.rosdistro,
                              newfiles={},
-                             meta=args.meta)
+                             meta=args.meta,
+                             no_comments=args.no_comments)
         print('Successfully created files in %s. Please adjust the values in package.xml.' % target_path)
     except ValueError as vae:
         parser.error(str(vae))


### PR DESCRIPTION
Example:

```
catkin_create_pkg --no_comments test
cat test/package.xml
Created file test/package.xml
Created file test/CMakeLists.txt
Successfully created files in /home/lucasw/ros/test. Please adjust the values in package.xml.
<?xml version="1.0"?>
<package format="2">
  <name>test</name>
  <version>0.0.0</version>
  <description>The test package</description>

  <maintainer email="lucasw@todo.todo">lucasw</maintainer>

  <license>TODO</license>

  <buildtool_depend>catkin</buildtool_depend>

  <export>

  </export>
</package>
```