### PR TITLE
Add GitHub Actions workflow for catkin_pkg CI.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,53 @@
+name: catkin_pkg-ci
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: ['*']
+
+jobs:
+    build:
+      strategy:
+        matrix:
+          os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04, macos-latest]
+          python: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9]
+          exclude:
+          - os: ubuntu-16.04
+            python: 3.6
+          - os: ubuntu-16.04
+            python: 3.7
+          - os: ubuntu-16.04
+            python: 3.8
+          - os: ubuntu-16.04
+            python: 3.9
+          - os: ubuntu-18.04
+            python: 3.5
+          - os: ubuntu-20.04
+            python: 2.7
+          - os: ubuntu-20.04
+            python: 3.5
+          - os: ubuntu-20.04
+            python: 3.6
+          - os: ubuntu-20.04
+            python: 3.7
+          - os: macos-latest
+            python: 3.5
+          - os: macos-latest
+            python: 3.6
+      name: rosdep tests
+      runs-on: ${{matrix.os}}
+
+      steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{matrix.python}}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{matrix.python}}
+      - name: Install dependencies
+        run: |
+          python -m pip install nose coverage argparse python-dateutil pyparsing
+          python -m pip install flake8 flake8-blind-except flake8-builtins flake8-class-newline flake8-comprehensions flake8-deprecated flake8-docstrings flake8-import-order flake8-quotes
+      - name: Run tests
+        run: |
+          python -m nose -s --tests test


### PR DESCRIPTION
Travis CI is becoming increasingly unavailable. This ports the same test suite to run via GitHub Actions based on the workflow I used for rosdep. It does add additional operating systems and python versions to the test matrix.