### PR TITLE
Address flake8 blind Exception errors.

### DIFF
--- a/src/catkin_pkg/cli/package_version.py
+++ b/src/catkin_pkg/cli/package_version.py
@@ -35,5 +35,5 @@ def main():
             new_version = bump_version(version, args.bump)
             update_versions(packages.keys(), new_version)
             print('%s -> %s' % (version, new_version))
-    except Exception as e:
+    except Exception as e:  # noqa: B902
         sys.exit(str(e))

--- a/src/catkin_pkg/package.py
+++ b/src/catkin_pkg/package.py
@@ -39,6 +39,7 @@ import os
 import re
 import sys
 import xml.dom.minidom as dom
+from xml.parsers.expat import ExpatError
 
 from catkin_pkg.condition import evaluate_condition
 
@@ -539,7 +540,7 @@ def has_ros_schema_reference_string(data):
         data = data.encode('utf-8')
     try:
         root = dom.parseString(data)
-    except Exception:
+    except ExpatError:
         # invalid XML
         return False
 
@@ -594,7 +595,7 @@ def parse_package_string(data, filename=None, warnings=None):
         data = data.encode('utf-8')
     try:
         root = dom.parseString(data)
-    except Exception as ex:
+    except ExpatError as ex:
         raise InvalidPackage('The manifest contains invalid XML:\n%s' % ex, filename)
 
     pkg = Package(filename)

--- a/test/test_metapackage.py
+++ b/test/test_metapackage.py
@@ -62,11 +62,7 @@ def assert_warning(warnreg):
 
 
 def _validate_metapackage(path, package):
-    try:
-        validate_metapackage(path, package)
-    except Exception:
-        # print('on package ' + package.name, file=sys.stderr)
-        raise
+    validate_metapackage(path, package)
 
 
 class TestMetapackageValidation(unittest.TestCase):


### PR DESCRIPTION
Update six try/except blocks to catch specific and expected errors. The release of flake8-blind-except v0.2.0 on1/7/2021 (https://github.com/elijahandrews/flake8-blind-except/releases/tag/v0.2.0) caused flake8 build errors on these blocks.

Also add three tests for improperly formatted package XML.

Signed-off-by: Sid Faber <sid.faber@canonical.com>