### PR TITLE
Stop using an undocumented docutils API

### DIFF
--- a/src/catkin_pkg/changelog.py
+++ b/src/catkin_pkg/changelog.py
@@ -231,9 +231,9 @@ def processes_changelog_children(changelog, children):
         elif isinstance(child, docutils.nodes.title) or isinstance(child, docutils.nodes.subtitle):
             version, date = None, None
             # See if the title has a text element in it
-            if len(child.children) > 0 and isinstance(child.children[0], docutils.nodes.Text):
+            if len(child.children) > 0 and any(isinstance(c, docutils.nodes.Text) for c in child.traverse()):
                 # Extract version and date from (sub-)title
-                title_text = child.children[0].rawsource
+                title_text = child.astext()
                 try:
                     version, date = version_and_date_from_title(title_text)
                 except InvalidSectionTitle:


### PR DESCRIPTION
It looks like docutils planned to deprecate this undocumented API in their 0.18 release, but some internal changes to avoid that deprecation removed this field from the API.

From what I can tell, this code is trying to extract the text from the subtitle of each subsection to parse the date and version number for existing entries. The astext function should give us the title stripped of formatting, which is probably what we want to parse anyway.