### PR TITLE
Remove newlines in package description for compatibility with new setuptools

### DIFF
--- a/src/catkin_pkg/python_setup.py
+++ b/src/catkin_pkg/python_setup.py
@@ -99,9 +99,9 @@ def generate_distutils_setup(package_xml_path=os.path.curdir, **kwargs):
         data['url'] = package.urls[0].url
 
     if len(package.description) <= 200:
-        data['description'] = package.description
+        data['description'] = package.description.replace('\n', ' ')
     else:
-        data['description'] = package.description[:197] + '...'
+        data['description'] = package.description[:197].replace('\n', ' ') + '...'
         data['long_description'] = package.description
 
     data['license'] = ', '.join(package.licenses)


### PR DESCRIPTION
…uptools

Currently many builds are broken with the newest setuptools
This is because of https://github.com/pypa/setuptools/pull/2870
See e.g. https://github.com/pypa/setuptools/issues/1390 https://github.com/pypa/setuptools/issues/2895 https://github.com/pypa/setuptools/issues/2893