### PR TITLE
Update release suites.

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -11,8 +11,8 @@ Depends3: python3-catkin-pkg-modules (>= 0.4.24), python3-dateutil, python3-docu
 Conflicts: catkin, python3-catkin-pkg
 Conflicts3: catkin, python-catkin-pkg
 Copyright-File: LICENSE
-Suite: xenial yakkety zesty artful bionic cosmic disco eoan jessie stretch buster
-Suite3: xenial yakkety zesty artful bionic cosmic disco eoan focal jessie stretch buster
+Suite: bionic cosmic disco eoan jessie stretch buster
+Suite3: bionic cosmic disco eoan focal jammy buster bullseye
 Python2-Depends-Name: python
 X-Python3-Version: >= 3.4
 Setup-Env-Vars: SKIP_PYTHON_MODULES=1
@@ -26,8 +26,8 @@ Conflicts3: catkin, python3-catkin-pkg (<< 0.3.0)
 Replaces: python-catkin-pkg (<< 0.3.0)
 Replaces3: python3-catkin-pkg (<< 0.3.0)
 Copyright-File: LICENSE
-Suite: xenial yakkety zesty artful bionic cosmic disco eoan jessie stretch buster
-Suite3: xenial yakkety zesty artful bionic cosmic disco eoan focal jessie stretch buster
+Suite: bionic cosmic disco eoan jessie stretch buster
+Suite3: bionic cosmic disco eoan focal jammy buster bullseye
 Python2-Depends-Name: python
 X-Python3-Version: >= 3.4
 Setup-Env-Vars: SKIP_PYTHON_SCRIPTS=1


### PR DESCRIPTION
* Drop Ubuntu Xenial and surrounding non-LTS distributions.
* Drop Debian Jessie and Debian Stretch. (Official security support for
  Debian Stretch ended in July 2020 and Jessie even earlier.)
* Add Debian Bullseye for Python 3.
* Add Ubuntu Jammy for Python 3.

Although the non-LTS Ubuntu releases between Bionic and Focal are no
longer supported I have not removed them as the pattern I've observed
the most is not to remove these distributions until removing the
surrounding LTS distribution. However, if pressed I would not fight to
keep those suites in the release list.