### PR TITLE
Drop Python 2.7 CI on macOS.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,8 +14,6 @@ jobs:
           include:
           - os: ubuntu-18.04
             python: 2.7
-          - os: macos-latest
-            python: 2.7
           - os: ubuntu-18.04
             python: 3.6
       name: catkin_pkg tests


### PR DESCRIPTION
It seems that the 2.7 binary used by the setup-python action on GitHub
no longer provides 2.7.

```
Run actions/setup-python@v1
Error: Version 2.7 with arch x64 not found
```