### PR TITLE
Use unittest.mock where possible

### DIFF
--- a/test/test_package.py
+++ b/test/test_package.py
@@ -20,7 +20,10 @@ from catkin_pkg.package import (
     Person,
 )
 
-from mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 
 sys.stderr = sys.stdout
 

--- a/test/test_package_version.py
+++ b/test/test_package_version.py
@@ -9,7 +9,10 @@ from catkin_pkg.package_version import bump_version
 from catkin_pkg.package_version import update_changelog_sections
 from catkin_pkg.package_version import update_versions
 
-import mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 
 from .util import in_temporary_directory
 
@@ -69,7 +72,7 @@ class PackageVersionTest(unittest.TestCase):
         temp_file = os.path.join(directory, 'changelog')
         missing_changelogs_but_forthcoming = {}
         # Mock the Changelog object from catkin_pkg
-        mock_changelog = mock.Mock()
+        mock_changelog = Mock()
         # Create a changelog entry with a unicode char.
         mock_changelog.rst = ('^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n'
                               'Changelog for package fake_pkg\n'

--- a/test/test_templates.py
+++ b/test/test_templates.py
@@ -8,7 +8,10 @@ from catkin_pkg.package_templates import _create_include_macro, _create_targetli
     create_cmakelists, create_package_files, create_package_xml, PackageTemplate
 from catkin_pkg.python_setup import generate_distutils_setup
 
-from mock import MagicMock, Mock
+try:
+    from unittest.mock import MagicMock, Mock
+except ImportError:
+    from mock import MagicMock, Mock
 
 
 def u(line):

--- a/test/test_topological_order.py
+++ b/test/test_topological_order.py
@@ -3,7 +3,10 @@ from __future__ import print_function
 import sys
 import unittest
 
-from mock import Mock
+try:
+    from mock import Mock
+except ImportError:
+    from unittest.mock import Mock
 
 try:
     from catkin_pkg.topological_order import topological_order_packages, _PackageDecorator, \


### PR DESCRIPTION
The 'unittest.mock' module has been present since Python 3.3, and some platforms are now dropping the 'mock' backport package.