### PR TITLE
Declare test dependencies in [test] extra

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,8 +27,7 @@ jobs:
           python-version: ${{matrix.python}}
       - name: Install dependencies
         run: |
-          python -m pip install argparse coverage docutils mock nose pyparsing python-dateutil
-          python -m pip install flake8 flake8-blind-except flake8-builtins flake8-class-newline flake8-comprehensions flake8-deprecated flake8-docstrings flake8-import-order flake8-quotes
+          python -m pip install -U -e .[test]
       - name: Run tests
         run: |
           python -m nose -s --tests test

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,20 @@ kwargs = {
     'long_description': 'Library for retrieving information about catkin packages.',
     'license': 'BSD',
     'install_requires': install_requires,
+    'extras_require': {
+        'test': [
+            'flake8',
+            'flake8-blind-except',
+            'flake8-builtins',
+            'flake8-class-newline',
+            'flake8-comprehensions',
+            'flake8-deprecated',
+            'flake8-docstrings',
+            'flake8-import-order',
+            'flake8-quotes',
+            "mock; python_version < '3.3'",
+            'nose',
+        ]},
 }
 if 'SKIP_PYTHON_MODULES' in os.environ:
     kwargs['packages'] = []


### PR DESCRIPTION
Formally declaring the test dependencies somewhere is a good idea, and allows tools like `colcon` to discover them.

['extras_require']['test'] is where we put these dependencies in colcon itself, but there doesn't appear to be a strong consensus among the packaging community regarding where to list these, and many options aren't compatible with python 2, which is still supported in this package. This option seems to meet all of our needs.

Also make the 'mock' dependency conditional, now that this package supports using unittest.mock.