### PR TITLE
Run tests with pytest instead of nose

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,4 +30,4 @@ jobs:
           python -m pip install -U -e .[test]
       - name: Run tests
         run: |
-          python -m nose -s --tests test
+          python -m pytest -s test

--- a/Makefile
+++ b/Makefile
@@ -27,4 +27,4 @@ testsetup:
 	echo "running ${NAME} tests"
 
 test: testsetup
-	cd test && nosetests && nosetests3
+	cd test && pytest && pytest-3

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ kwargs = {
             'flake8-import-order',
             'flake8-quotes',
             "mock; python_version < '3.3'",
-            'nose',
+            'pytest',
         ]},
 }
 if 'SKIP_PYTHON_MODULES' in os.environ:

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,4 +1,6 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.join('..', 'src'))
+sys.path.insert(0, os.path.join(
+    os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+    'src'))


### PR DESCRIPTION
Official nose documentation recommends users migrate to a more supported platform.

https://nose.readthedocs.io/en/latest/#note-to-users