### PR TITLE
Mark linter test and declare cov/junit module name

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,8 @@
+[tool:pytest]
+junit_suite_name = catkin_pkg
+markers =
+  flake8
+  linter
+
+[coverage:run]
+source = catkin_pkg

--- a/test/test_flake8.py
+++ b/test/test_flake8.py
@@ -18,8 +18,11 @@ import os
 import sys
 
 from flake8.api.legacy import get_style_guide
+import pytest
 
 
+@pytest.mark.flake8
+@pytest.mark.linter
 def test_flake8():
     # Configure flake8 using the .flake8 file in the root of this repository.
     style_guide = get_style_guide()


### PR DESCRIPTION
Using the `setup.cfg` to tell coverage the name of the module we're interested in is better than passing it on the command line every time we invoke pytest with `--cov`.

Declaring the `junit_suite_name` will make the tests categories correctly in our infrastructure.

Marking tests appropriately will allow us to be more selective about what tests are run.