### PR TITLE
Add plaintext description field to Package.

### DIFF
--- a/src/catkin_pkg/package.py
+++ b/src/catkin_pkg/package.py
@@ -628,7 +628,7 @@ def parse_package_string(data, filename=None, warnings=None):
 
     # description
     pkg.description = _get_node_value(_get_node(root, 'description', filename), allow_xml=True, apply_str=False)
-    pkg.plaintext_description = _get_node_text(_get_node(root, 'description', filename))
+    pkg.plaintext_description = re.sub(' +(\n+) +', r'\1', _get_node_text(_get_node(root, 'description', filename)), flags=re.MULTILINE)
 
     # at least one maintainer, all must have email
     maintainers = _get_nodes(root, 'maintainer')

--- a/src/catkin_pkg/package.py
+++ b/src/catkin_pkg/package.py
@@ -137,6 +137,9 @@ class Package(object):
             data[attr] = getattr(self, attr)
         return str(data)
 
+    def plaintext_description(self):
+        return self.description
+
     def has_buildtool_depend_on_catkin(self):
         """
         Return True if this Package buildtool depends on catkin, otherwise False.

--- a/src/catkin_pkg/package.py
+++ b/src/catkin_pkg/package.py
@@ -813,7 +813,7 @@ def _get_node_text(node, strip=True):
     value = ''
     for child in node.childNodes:
         if child.nodeType == child.TEXT_NODE:
-            value += re.sub('\s+', ' ', child.data)
+            value += re.sub(r'\s+', ' ', child.data)
         elif child.nodeType == child.ELEMENT_NODE:
             if child.tagName == 'br':
                 value += '\n'

--- a/src/catkin_pkg/package.py
+++ b/src/catkin_pkg/package.py
@@ -137,7 +137,7 @@ class Package(object):
             data[attr] = getattr(self, attr)
         return str(data)
 
-    def plaintext_description(self):
+    def get_plaintext_description(self):
         return self.description
 
     def has_buildtool_depend_on_catkin(self):

--- a/src/catkin_pkg/package.py
+++ b/src/catkin_pkg/package.py
@@ -60,6 +60,7 @@ class Package(object):
         'version',
         'version_compatibility',
         'description',
+        'plaintext_description',
         'maintainers',
         'licenses',
         'urls',
@@ -138,7 +139,7 @@ class Package(object):
         return str(data)
 
     def get_plaintext_description(self):
-        return self.description
+        return self.plaintext_description
 
     def has_buildtool_depend_on_catkin(self):
         """
@@ -627,6 +628,7 @@ def parse_package_string(data, filename=None, warnings=None):
 
     # description
     pkg.description = _get_node_value(_get_node(root, 'description', filename), allow_xml=True, apply_str=False)
+    pkg.plaintext_description = _get_node_text(_get_node(root, 'description', filename))
 
     # at least one maintainer, all must have email
     maintainers = _get_nodes(root, 'maintainer')
@@ -804,6 +806,23 @@ def _get_node_value(node, allow_xml=False, apply_str=True):
         value = (''.join([n.data for n in node.childNodes if n.nodeType == n.TEXT_NODE])).strip(' \n\r\t')
     if apply_str:
         value = str(value)
+    return value
+
+
+def _get_node_text(node, strip=True):
+    value = ''
+    for child in node.childNodes:
+        if child.nodeType == child.TEXT_NODE:
+            value += re.sub('\s+', ' ', child.data)
+        elif child.nodeType == child.ELEMENT_NODE:
+            if child.tagName == 'br':
+                value += '\n'
+            else:
+                value += _get_node_text(child, strip=False)
+        else:
+            assert 'unreachable'
+    if strip:
+        value = value.strip()
     return value
 
 

--- a/src/catkin_pkg/package.py
+++ b/src/catkin_pkg/package.py
@@ -138,9 +138,6 @@ class Package(object):
             data[attr] = getattr(self, attr)
         return str(data)
 
-    def get_plaintext_description(self):
-        return self.plaintext_description
-
     def has_buildtool_depend_on_catkin(self):
         """
         Return True if this Package buildtool depends on catkin, otherwise False.

--- a/test/data/package/xhtml_description.txt
+++ b/test/data/package/xhtml_description.txt
@@ -1,0 +1,4 @@
+A package with an XHTML description.
+
+This package contains several xhtml tags which are, according to REP-149, meant to be properly handled but "XML tags and multiple whitespaces" may be stripped in some situations. Another sentence in this quasi-paragraph will continue to appear on the same plaintext line because there was no <br/> tag to indicate a newline should appear in the output text.
+This text should appear on a subsequent line.

--- a/test/data/package/xhtml_description.xml
+++ b/test/data/package/xhtml_description.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<package>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>xhtml_descrption</name>
   <version>0.1.0</version>
   <description>
@@ -16,7 +17,7 @@
   <license>BSD</license>
   <buildtool_depend>catkin</buildtool_depend>
 
-  <run_depend>foo</run_depend>
-  <run_depend>bar</run_depend>
-  <run_depend>baz</run_depend>
+  <exec_depend>foo</exec_depend>
+  <exec_depend>bar</exec_depend>
+  <exec_depend>baz</exec_depend>
 </package>

--- a/test/data/package/xhtml_description.xml
+++ b/test/data/package/xhtml_description.xml
@@ -11,6 +11,11 @@
     <a href="https://www.ros.org/reps/rep-0149.html#description">REP-149</a>,
     meant to be properly handled but &quot;XML tags and multiple
     whitespaces&quot; may be stripped in some situations.
+    Another sentence in this quasi-paragraph will continue to appear
+    on the same plaintext line because there was no &lt;br/&gt; tag to indicate
+    a newline should appear in the output text.
+    <br/>
+    This text should appear on a subsequent line.
   </description>
 
   <maintainer email="user@todo.todo">üser</maintainer>

--- a/test/data/package/xhtml_description.xml
+++ b/test/data/package/xhtml_description.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<package>
+  <name>xhtml_descrption</name>
+  <version>0.1.0</version>
+  <description>
+    A package with an XHTML description.
+    <br/><br/>
+    This package contains <em>several</em> xhtml tags which
+    are, according to
+    <a href="https://www.ros.org/reps/rep-0149.html#description">REP-149</a>,
+    meant to be properly handled but &quot;XML tags and multiple
+    whitespaces&quot; may be stripped in some situations.
+  </description>
+
+  <maintainer email="user@todo.todo">üser</maintainer>
+  <license>BSD</license>
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <run_depend>foo</run_depend>
+  <run_depend>bar</run_depend>
+  <run_depend>baz</run_depend>
+</package>

--- a/test/test_package.py
+++ b/test/test_package.py
@@ -388,7 +388,7 @@ class PackageTest(unittest.TestCase):
         assert package.get_plaintext_description() == """\
 A package with an XHTML description.
 
-This package contains several xhtml tags which are, according to REP-149, meant to be handled properly but "XML tags and multiple whitespaces" may be stripped in some situations. Ahother sentence in this quasi-paragraph will continue to appear on the same plaintext line becuase there was no <br/> tag to indicate a newline should appear in the output text.
+This package contains several xhtml tags which are, according to REP-149, meant to be properly handled but "XML tags and multiple whitespaces" may be stripped in some situations. Another sentence in this quasi-paragraph will continue to appear on the same plaintext line because there was no <br/> tag to indicate a newline should appear in the output text.
 This text should appear on a subsequent line.\
 """
 

--- a/test/test_package.py
+++ b/test/test_package.py
@@ -385,7 +385,7 @@ class PackageTest(unittest.TestCase):
         filename = os.path.join(test_data_dir, 'xhtml_description.xml')
         package = parse_package(filename)
         assert package.description
-        assert package.get_plaintext_description() == """\
+        assert package.plaintext_description == """\
 A package with an XHTML description.
 
 This package contains several xhtml tags which are, according to REP-149, meant to be properly handled but "XML tags and multiple whitespaces" may be stripped in some situations. Another sentence in this quasi-paragraph will continue to appear on the same plaintext line because there was no <br/> tag to indicate a newline should appear in the output text.

--- a/test/test_package.py
+++ b/test/test_package.py
@@ -383,14 +383,14 @@ class PackageTest(unittest.TestCase):
 
     def test_parse_package_xhtml_description(self):
         filename = os.path.join(test_data_dir, 'xhtml_description.xml')
+        expected_plaintext_description = None
+        with open(os.path.join(test_data_dir, 'xhtml_description.txt'), 'r') as f:
+            # Strip the trailing newline from the data file.
+            expected_plaintext_description = f.read().rstrip('\n')
         package = parse_package(filename)
         assert package.description
-        assert package.plaintext_description == """\
-A package with an XHTML description.
 
-This package contains several xhtml tags which are, according to REP-149, meant to be properly handled but "XML tags and multiple whitespaces" may be stripped in some situations. Another sentence in this quasi-paragraph will continue to appear on the same plaintext line because there was no <br/> tag to indicate a newline should appear in the output text.
-This text should appear on a subsequent line.\
-"""
+        assert package.plaintext_description == expected_plaintext_description
 
     def test_parse_package_string(self):
         filename = os.path.join(test_data_dir, 'valid_package.xml')

--- a/test/test_package.py
+++ b/test/test_package.py
@@ -381,6 +381,16 @@ class PackageTest(unittest.TestCase):
         filename = os.path.join(test_data_dir, 'invalid_package.xml')
         self.assertRaises(InvalidPackage, parse_package, filename)
 
+    def test_parse_package_xhtml_description(self):
+        filename = os.path.join(test_data_dir, 'xhtml_description.xml')
+        package = parse_package(filename)
+        assert package.description
+        assert package.plaintext_description() == """
+A package with an XHTML description.
+
+This package contains several xhtml tags which are, according to REP-149, meant to be handled properly but "XML tags and multiple whitespaces" may be stripped in some situations.
+        """
+
     def test_parse_package_string(self):
         filename = os.path.join(test_data_dir, 'valid_package.xml')
         xml = _get_package_xml(filename)[0]

--- a/test/test_package.py
+++ b/test/test_package.py
@@ -385,7 +385,7 @@ class PackageTest(unittest.TestCase):
         filename = os.path.join(test_data_dir, 'xhtml_description.xml')
         package = parse_package(filename)
         assert package.description
-        assert package.plaintext_description() == """\
+        assert package.get_plaintext_description() == """\
 A package with an XHTML description.
 
 This package contains several xhtml tags which are, according to REP-149, meant to be handled properly but "XML tags and multiple whitespaces" may be stripped in some situations. Ahother sentence in this quasi-paragraph will continue to appear on the same plaintext line becuase there was no <br/> tag to indicate a newline should appear in the output text.

--- a/test/test_package.py
+++ b/test/test_package.py
@@ -388,8 +388,9 @@ class PackageTest(unittest.TestCase):
         assert package.plaintext_description() == """\
 A package with an XHTML description.
 
-This package contains several xhtml tags which are, according to REP-149, meant to be handled properly but "XML tags and multiple whitespaces" may be stripped in some situations.\
-        """
+This package contains several xhtml tags which are, according to REP-149, meant to be handled properly but "XML tags and multiple whitespaces" may be stripped in some situations. Ahother sentence in this quasi-paragraph will continue to appear on the same plaintext line becuase there was no <br/> tag to indicate a newline should appear in the output text.
+This text should appear on a subsequent line.\
+"""
 
     def test_parse_package_string(self):
         filename = os.path.join(test_data_dir, 'valid_package.xml')

--- a/test/test_package.py
+++ b/test/test_package.py
@@ -385,10 +385,10 @@ class PackageTest(unittest.TestCase):
         filename = os.path.join(test_data_dir, 'xhtml_description.xml')
         package = parse_package(filename)
         assert package.description
-        assert package.plaintext_description() == """
+        assert package.plaintext_description() == """\
 A package with an XHTML description.
 
-This package contains several xhtml tags which are, according to REP-149, meant to be handled properly but "XML tags and multiple whitespaces" may be stripped in some situations.
+This package contains several xhtml tags which are, according to REP-149, meant to be handled properly but "XML tags and multiple whitespaces" may be stripped in some situations.\
         """
 
     def test_parse_package_string(self):


### PR DESCRIPTION
This patch adds a `_get_node_text` function to the package module's xml processing toolset: a basic plaintext renderer for xhtml descriptions which also extracts text from formatting tags such as `<em>` or `<a>` although it does not render or preserve the href attribute on a tags in any way. All literal whitespace is compressed into a single ` ` so the only way to insert a newline into the plaintext description is by using a `<br>` tag. 

I used this to add a new `plaintext_description` field to a parsed package where I take the extra step of trimming whitespace around newlines even though they are technically valid it doesn't match the expectations established by first writing an xml description and then hand-rendering it as plaintext.


## Motivation and background

There are several cases where a package.xml description is meant to be "rendered" as plain text.
According to [REP-149](https://www.ros.org/reps/rep-0149.html#description) the description "may contain XHTML" but depending on where the description is used "XML tags and multiple whitespaces might be stripped".

The existing description field does not do any sort of whitespace manipulation, nor does it actually strip XHTML tags. This results in extremely odd formatting when used in plaintext contexts, such as a `PKG-INFO` file within a python sdist.

Consider the [description for actionlib](https://github.com/ros/actionlib/blob/3073509690976a8816636d41f04c013633f1c119/actionlib/package.xml#L6-L11)

```
  <description>
    The actionlib stack provides a standardized interface for
    interfacing with preemptable tasks. Examples of this include moving
    the base to a target location, performing a laser scan and returning
    the resulting point cloud, detecting the handle of a door, etc.
  </description>
```

This is currently parsed as
```
'The actionlib stack provides a standardized interface for\n    interfacing with preemptable tasks. Examples of this include moving\n    the base to a target location, performing a laser scan and returning\n    the resulting point cloud, detecting the handle of a door, etc.'
```

All interior whitespace is retained which results in an oddly formatted description since the line breaks do not have any inherent semantic value but appear to be formatted just to adhere to 72-character line widths.

When discussing #316 and #326 both of which are proposals to manipulate the description in order to conform to changes in setuptools each proposal assumed that lines would be "sensibly formatted" to start with and that taking either the first "line" or replacing line breaks with single spaces would retain a sensibly formatted, if truncated description. However if we took only the first line of the above description (as in #326) it would yield:
```
The actionlib stack provides a standardized interface for
```

If we we compressed newlines into spaces and then took the first 200 characters (as in #316) it would yield:
```
The actionlib stack provides a standardized interface for     interfacing with preemptable tasks. Examples of this include moving     the base to a target location, performing a laser scan and retu...
```

While trying to decide which of these is the "lesser of two unfortunates" I got it into my head that we should really be treating these like an HTML renderer does and treating any combination of whitespace as a single space. I turned to the XML specification to back me up on this. From section [2.10 on white space handling](https://www.w3.org/TR/2008/REC-xml-20081126/#sec-white-space)

> An XML processor MUST always pass all characters in a document that are not markup through to the application. A validating XML processor MUST also inform the application which of these characters constitute white space appearing in element content.

Which prompts me to conclude that catkin_pkg is our application and that we should be deciding how to treat whitespace. The description in REP-149 specifically states that whitespace may be stripped in certain situations and I think that a plaintext "rendering" of an xhtml description field like actionlib's should result in the following string:

```
The actionlib stack provides a standardized interface for interfacing with preemptable tasks. Examples of this include moving the base to a target location, performing a laser scan and returning the resulting point cloud, detecting the handle of a door, etc.
```
