### PR TITLE
update catkin_prepare_release to support setup.py files

### DIFF
--- a/src/catkin_pkg/cli/prepare_release.py
+++ b/src/catkin_pkg/cli/prepare_release.py
@@ -133,6 +133,7 @@ def check_clean_working_copy(base_path, vcs_type):
 def commit_files(base_path, vcs_type, packages, packages_with_changelogs, message, dry_run=False):
     cmd = [_find_executable(vcs_type), 'commit', '-m', message]
     cmd += [os.path.join(p, PACKAGE_MANIFEST_FILENAME) for p in packages.keys()]
+    cmd += [s for s in [os.path.join(p, 'setup.py') for p in packages.keys()] if os.path.exists(s)]
     cmd += [path for path, _, _ in packages_with_changelogs.values()]
     if not dry_run:
         try:
@@ -266,17 +267,19 @@ def _main():
     # complain about packages with upper case character since they won't be releasable with bloom
     unsupported_pkg_names = []
     invalid_pkg_names = []
+    valid_build_types = ['catkin', 'ament_cmake', 'ament_python']
     for package in packages.values():
         build_types = [export.content for export in package.exports if export.tagname == 'build_type']
         build_type = build_types[0] if build_types else 'catkin'
-        if build_type not in ('catkin', 'ament_cmake'):
+        if build_type not in valid_build_types:
             unsupported_pkg_names.append(package.name)
         if package.name != package.name.lower():
             invalid_pkg_names.append(package.name)
     if unsupported_pkg_names:
         print(
             fmt(
-                "@{yf}Warning: the following package are not of build_type catkin or ament_cmake and may require manual steps to release': %s" %
+                "@{yf}Warning: the following package are not of build_type %s and may require manual steps to release': %s" %
+                str(valid_build_types),
                 ', '.join([('@{boldon}%s@{boldoff}' % p) for p in sorted(unsupported_pkg_names)])
             ), file=sys.stderr)
         if not args.non_interactive and not prompt_continue('Continue anyway', default=False):
@@ -304,6 +307,10 @@ def _main():
                 raise RuntimeError(fmt(
                     "@{rf}Invalid metapackage at path '@{boldon}%s@{boldoff}':\n  %s\n\nSee requirements for metapackages: %s" %
                     (os.path.abspath(pkg_path), str(e), metapackage.DEFINITION_URL)))
+        # verify that the setup.py files don't have modifications pending
+        setup_py_path = os.path.join(pkg_path, 'setup.py')
+        if os.path.exists(setup_py_path) and has_changes(base_path, setup_py_path, vcs_type):
+            local_modifications.append(setup_py_path)
 
     # fetch current version and verify that all packages have same version number
     old_version = verify_equal_package_versions(packages.values())

--- a/test/test_package_version.py
+++ b/test/test_package_version.py
@@ -4,6 +4,7 @@ import shutil
 import tempfile
 import unittest
 
+from catkin_pkg.package_version import _replace_setup_py_version
 from catkin_pkg.package_version import _replace_version
 from catkin_pkg.package_version import bump_version
 from catkin_pkg.package_version import update_changelog_sections
@@ -44,6 +45,34 @@ class PackageVersionTest(unittest.TestCase):
                          _replace_version("<package><version abi='0.1.0'>0.1.0</version></package>", '0.1.1'))
         self.assertRaises(RuntimeError, _replace_version, '<package></package>', '0.1.1')
         self.assertRaises(RuntimeError, _replace_version, '<package><version>0.1.1</version><version>0.1.1</version></package>', '0.1.1')
+
+    def test_replace_setup_py_version(self):
+        self.assertEqual(
+            'version="1.0.0",',
+            _replace_setup_py_version('version="0.0.1",', '1.0.0'))
+        self.assertEqual(
+            'version=\'1.0.0\',',
+            _replace_setup_py_version('version=\'0.0.1\',', '1.0.0'))
+        self.assertRaises(
+            RuntimeError,
+            _replace_setup_py_version,
+            '',
+            '1.0.0')
+        self.assertRaises(
+            RuntimeError,
+            _replace_setup_py_version,
+            '0.1',
+            '1.0.0')
+        self.assertRaises(
+            RuntimeError,
+            _replace_setup_py_version,
+            'version=something,',
+            '1.0.0')
+        self.assertRaises(
+            RuntimeError,
+            _replace_setup_py_version,
+            'version="0.0.1",version="0.0.1",',
+            '1.0.0')
 
     def test_update_versions(self):
         try:


### PR DESCRIPTION
I know some people don't like using `catkin_prepare_release`, but I personally enjoy it because I know what magic is happening and I like the consistency it brings in commit messages, tags, and changelog headings. But until this pull request it didn't support `setup.py` based packages because it would not update the version in the `setup.py`, only the `package.xml`. This pull request changes that and adds `ament_python` to the list of supported build types for this tool.