### PR TITLE
[Refine #331] Use package.get_build_type()

### DIFF
--- a/src/catkin_pkg/cli/prepare_release.py
+++ b/src/catkin_pkg/cli/prepare_release.py
@@ -10,7 +10,6 @@ from catkin_pkg import metapackage
 from catkin_pkg.changelog import CHANGELOG_FILENAME, get_changelog_from_path
 from catkin_pkg.package import InvalidPackage, PACKAGE_MANIFEST_FILENAME
 from catkin_pkg.package_version import bump_version
-from catkin_pkg.package_version import extract_build_type_from_package_object
 from catkin_pkg.package_version import get_forthcoming_label, update_changelog_sections, update_versions
 from catkin_pkg.packages import find_packages, verify_equal_package_versions
 from catkin_pkg.terminal_color import disable_ANSI_colors, fmt
@@ -270,7 +269,7 @@ def _main():
     invalid_pkg_names = []
     valid_build_types = ['catkin', 'ament_cmake', 'ament_python']
     for package in packages.values():
-        build_type = extract_build_type_from_package_object(package)
+        build_type = package.get_build_type()
         if build_type not in valid_build_types:
             unsupported_pkg_names.append(package.name)
         if package.name != package.name.lower():

--- a/src/catkin_pkg/package_version.py
+++ b/src/catkin_pkg/package_version.py
@@ -123,17 +123,6 @@ def _check_for_version_comment(package_str, new_version):
     return comment
 
 
-def extract_build_type_from_package_object(package_obj):
-    """
-    Extract the build type from a given package xml object.
-
-    :returns: the build type of the package
-    :rtype: str
-    """
-    build_types = [export.content for export in package_obj.exports if export.tagname == 'build_type']
-    return build_types[0] if build_types else 'catkin'
-
-
 def update_versions(packages, new_version):
     """
     Bulk replace of version: searches for package.xml and setup.py files directly in given folders and replaces version tag within.
@@ -160,7 +149,7 @@ def update_versions(packages, new_version):
         setup_py_path = os.path.join(path, 'setup.py')
         if os.path.exists(setup_py_path):
             # Only update setup.py for ament_python packages.
-            build_type = extract_build_type_from_package_object(package_obj)
+            build_type = package_obj.get_build_type()
             if build_type == 'ament_python':
                 with open(setup_py_path, 'r') as f:
                     setup_py_str = f.read()


### PR DESCRIPTION
This is a proposal to use the existing Package.get_build_type() method. As far as I can tell in local testing this works fine and avoids adding an extra function to do the same thing.