### PR TITLE
Fix catkin_package_version after API change.

### DIFF
--- a/src/catkin_pkg/cli/package_version.py
+++ b/src/catkin_pkg/cli/package_version.py
@@ -33,7 +33,7 @@ def main():
         else:
             # bump the version number
             new_version = bump_version(version, args.bump)
-            update_versions(packages.keys(), new_version)
+            update_versions(packages, new_version)
             print('%s -> %s' % (version, new_version))
     except Exception as e:  # noqa: B902
         sys.exit(str(e))


### PR DESCRIPTION
This is a regression from #331 which updated this API.

During review we somehow missed this usage of catkin_pkg.package_version.update_version within this repository.