### PR TITLE
Add API method for getting all build_types regardless of conditions.

### DIFF
--- a/src/catkin_pkg/package.py
+++ b/src/catkin_pkg/package.py
@@ -166,6 +166,23 @@ class Package(object):
             return build_type_exports[0]
         raise InvalidPackage('Only one <build_type> element is permitted.', self.filename)
 
+    def get_build_types(self):
+        """
+        Return values of export/build_type elements without conditional filtering, or ['catkin'] if unspecified.
+
+        :returns: package build types
+        :rtype: List[str]
+        :raises: :exc:`InvalidPackage`
+        """
+        # for backward compatibility a build type without an evaluated
+        # condition is still being considered (i.e. evaluated_condition is None)
+        build_type_exports = [
+            e.content for e in self.exports
+            if e.tagname == 'build_type']
+        if not build_type_exports:
+            return ['catkin']
+        return build_type_exports
+
     def has_invalid_metapackage_dependencies(self):
         """
         Return True if this package has invalid dependencies for a metapackage.


### PR DESCRIPTION
This is more of a spike than anything. I'm not convinced this is the
best way to go for this particular issue but it was the first thought
that came to my head.

Of possibly more concern is that this gets us past the "first hurdle"
but I'm unclear why the simple version bump doesn't crash also.