### PR TITLE
Consider all build types when updating package versions

### DIFF
--- a/src/catkin_pkg/cli/prepare_release.py
+++ b/src/catkin_pkg/cli/prepare_release.py
@@ -269,8 +269,8 @@ def _main():
     invalid_pkg_names = []
     valid_build_types = ['catkin', 'ament_cmake', 'ament_python']
     for package in packages.values():
-        build_type = package.get_build_type()
-        if build_type not in valid_build_types:
+        build_types = package.get_build_types()
+        if any(build_type not in valid_build_types for build_type in build_types):
             unsupported_pkg_names.append(package.name)
         if package.name != package.name.lower():
             invalid_pkg_names.append(package.name)

--- a/src/catkin_pkg/package_version.py
+++ b/src/catkin_pkg/package_version.py
@@ -149,8 +149,8 @@ def update_versions(packages, new_version):
         setup_py_path = os.path.join(path, 'setup.py')
         if os.path.exists(setup_py_path):
             # Only update setup.py for ament_python packages.
-            build_type = package_obj.get_build_type()
-            if build_type == 'ament_python':
+            build_types = package_obj.get_build_types()
+            if 'ament_python' in build_types:
                 with open(setup_py_path, 'r') as f:
                     setup_py_str = f.read()
                 try:


### PR DESCRIPTION
Closes #336.

This PR is currently stacked on #337 and should be rebased once that PR merges.
Using that new API method we can consider all package build types when checking for catkin_prepare_release support and when updating repository contents in `catkin_pkg.package_versions.update_versions`.