### PR TITLE
Use renamed function name after #337.

### DIFF
--- a/src/catkin_pkg/cli/prepare_release.py
+++ b/src/catkin_pkg/cli/prepare_release.py
@@ -269,7 +269,7 @@ def _main():
     invalid_pkg_names = []
     valid_build_types = ['catkin', 'ament_cmake', 'ament_python']
     for package in packages.values():
-        build_types = package.get_build_types()
+        build_types = package.get_unconditional_build_types()
         if any(build_type not in valid_build_types for build_type in build_types):
             unsupported_pkg_names.append(package.name)
         if package.name != package.name.lower():

--- a/src/catkin_pkg/package_version.py
+++ b/src/catkin_pkg/package_version.py
@@ -149,7 +149,7 @@ def update_versions(packages, new_version):
         setup_py_path = os.path.join(path, 'setup.py')
         if os.path.exists(setup_py_path):
             # Only update setup.py for ament_python packages.
-            build_types = package_obj.get_build_types()
+            build_types = package_obj.get_unconditional_build_types()
             if 'ament_python' in build_types:
                 with open(setup_py_path, 'r') as f:
                     setup_py_str = f.read()


### PR DESCRIPTION
These patches were interleaved and #340 was not updated before being
merged.

Fixes #341 