### PR TITLE
Drop support for Python 2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,20 +9,18 @@ jobs:
     build:
       strategy:
         matrix:
-          os: [ubuntu-latest, macos-latest]
+          os: [ubuntu-22.04, macos-latest]
           python: ['3.7', '3.8', '3.9', '3.10']
           include:
-          - os: ubuntu-18.04
-            python: '2.7'
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             python: '3.6'
       name: catkin_pkg tests
       runs-on: ${{matrix.os}}
 
       steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python ${{matrix.python}}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{matrix.python}}
       - name: Install dependencies

--- a/bin/catkin_create_pkg
+++ b/bin/catkin_create_pkg
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/bin/catkin_find_pkg
+++ b/bin/catkin_find_pkg
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/bin/catkin_generate_changelog
+++ b/bin/catkin_generate_changelog
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/bin/catkin_package_version
+++ b/bin/catkin_package_version
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/bin/catkin_prepare_release
+++ b/bin/catkin_prepare_release
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/bin/catkin_tag_changelog
+++ b/bin/catkin_tag_changelog
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/bin/catkin_test_changelog
+++ b/bin/catkin_test_changelog
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 
@@ -39,6 +39,7 @@ kwargs = {
         'Programming Language :: Python',
         'License :: OSI Approved :: BSD License'
     ],
+    'python_requires': '>=3.6',
     'description': 'catkin package library',
     'long_description': 'Library for retrieving information about catkin packages.',
     'license': 'BSD',
@@ -59,7 +60,6 @@ kwargs = {
             'flake8-docstrings',
             'flake8-import-order',
             'flake8-quotes',
-            "mock; python_version < '3.3'",
             'pytest',
         ]},
 }

--- a/src/catkin_pkg/topological_order.py
+++ b/src/catkin_pkg/topological_order.py
@@ -222,7 +222,7 @@ def _reduce_cycle_set(packages_orig):
     :param packages: A dict mapping package name to ``_PackageDecorator`` objects ``dict``
     :returns: A list of package names from the input which could not easily be detected as not being part of a cycle.
     """
-    assert(packages_orig)
+    assert (packages_orig)
     packages = copy.copy(packages_orig)
     last_depended = None
     while len(packages) > 0:

--- a/src/catkin_pkg/topological_order.py
+++ b/src/catkin_pkg/topological_order.py
@@ -222,7 +222,7 @@ def _reduce_cycle_set(packages_orig):
     :param packages: A dict mapping package name to ``_PackageDecorator`` objects ``dict``
     :returns: A list of package names from the input which could not easily be detected as not being part of a cycle.
     """
-    assert (packages_orig)
+    assert packages_orig
     packages = copy.copy(packages_orig)
     last_depended = None
     while len(packages) > 0:

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -3,31 +3,19 @@ Debian-Version: 100
 ; catkin-pkg-modules same version as in:
 ; - setup.py
 ; - src/catkin_pkg/__init__.py
-Depends: python-argparse, python-catkin-pkg-modules (>= 0.5.2), python-dateutil, python-docutils
-; catkin-pkg-modules same version as in:
-; - setup.py
-; - src/catkin_pkg/__init__.py
 Depends3: python3-catkin-pkg-modules (>= 0.5.2), python3-dateutil, python3-docutils
-Conflicts: catkin, python3-catkin-pkg
 Conflicts3: catkin, python-catkin-pkg
 Copyright-File: LICENSE
-Suite: bionic cosmic disco eoan jessie stretch buster
-Suite3: bionic cosmic disco eoan focal jammy buster bullseye
-Python2-Depends-Name: python
-X-Python3-Version: >= 3.4
+Suite3: focal jammy buster bullseye bookworm
+X-Python3-Version: >= 3.6
 Setup-Env-Vars: SKIP_PYTHON_MODULES=1
 
 [catkin_pkg_modules]
 Source: catkin_pkg_modules
-Depends: python-argparse, python-dateutil, python-docutils, python-pyparsing
 Depends3: python3-dateutil, python3-docutils, python3-pyparsing
-Conflicts: catkin, python-catkin-pkg (<< 0.3.0)
 Conflicts3: catkin, python3-catkin-pkg (<< 0.3.0)
-Replaces: python-catkin-pkg (<< 0.3.0)
 Replaces3: python3-catkin-pkg (<< 0.3.0)
 Copyright-File: LICENSE
-Suite: bionic cosmic disco eoan jessie stretch buster
-Suite3: bionic cosmic disco eoan focal jammy buster bullseye
-Python2-Depends-Name: python
-X-Python3-Version: >= 3.4
+Suite3: focal jammy buster bullseye bookworm
+X-Python3-Version: >= 3.6
 Setup-Env-Vars: SKIP_PYTHON_SCRIPTS=1

--- a/test/test_package.py
+++ b/test/test_package.py
@@ -2,6 +2,7 @@ import os.path
 # Redirect stderr to stdout to suppress output in tests
 import sys
 import unittest
+from unittest.mock import Mock
 
 import xml.dom.minidom as dom
 from xml.parsers.expat import ExpatError
@@ -19,11 +20,6 @@ from catkin_pkg.package import (
     parse_package_string,
     Person,
 )
-
-try:
-    from unittest.mock import Mock
-except ImportError:
-    from mock import Mock
 
 sys.stderr = sys.stdout
 

--- a/test/test_package_version.py
+++ b/test/test_package_version.py
@@ -3,17 +3,13 @@ import os
 import shutil
 import tempfile
 import unittest
+from unittest.mock import Mock
 
 from catkin_pkg.package_version import _replace_setup_py_version
 from catkin_pkg.package_version import _replace_version
 from catkin_pkg.package_version import bump_version
 from catkin_pkg.package_version import update_changelog_sections
 from catkin_pkg.package_version import update_versions
-
-try:
-    from unittest.mock import Mock
-except ImportError:
-    from mock import Mock
 
 from .util import in_temporary_directory
 

--- a/test/test_templates.py
+++ b/test/test_templates.py
@@ -2,16 +2,12 @@ import os
 import shutil
 import tempfile
 import unittest
+from unittest.mock import MagicMock, Mock
 
 from catkin_pkg.package import Dependency, Export, PACKAGE_MANIFEST_FILENAME, parse_package, Url
 from catkin_pkg.package_templates import _create_include_macro, _create_targetlib_args, _safe_write_files, \
     create_cmakelists, create_package_files, create_package_xml, PackageTemplate
 from catkin_pkg.python_setup import generate_distutils_setup
-
-try:
-    from unittest.mock import MagicMock, Mock
-except ImportError:
-    from mock import MagicMock, Mock
 
 
 def u(line):

--- a/test/test_topological_order.py
+++ b/test/test_topological_order.py
@@ -2,11 +2,7 @@ from __future__ import print_function
 
 import sys
 import unittest
-
-try:
-    from mock import Mock
-except ImportError:
-    from unittest.mock import Mock
+from unittest.mock import Mock
 
 try:
     from catkin_pkg.topological_order import topological_order_packages, _PackageDecorator, \


### PR DESCRIPTION
* The minimum Python version is now 3.6
* Shebangs now use python3 specifically
* EOL Debian/Ubuntu suites have been dropped
* Upcoming Debian Bookworm has been added
* Use of the 'mock' backport package has been removed
* GitHub Actions have been updated to the latest major
* A new flake8 violation was addressed

This change should be immediately followed by a major version bump and release, leaving us plenty of room to backport fixes and features for Python 2 if we find that to be necessary someday.