### PR TITLE
Update Ubuntu and Debian platforms supported by catkin_pkg.

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -6,7 +6,7 @@ Debian-Version: 100
 Depends3: python3-catkin-pkg-modules (>= 1.0.0), python3-dateutil, python3-docutils
 Conflicts3: catkin, python-catkin-pkg
 Copyright-File: LICENSE
-Suite3: focal jammy buster bullseye bookworm
+Suite3: focal jammy noble bookworm trixie
 X-Python3-Version: >= 3.6
 Setup-Env-Vars: SKIP_PYTHON_MODULES=1
 


### PR DESCRIPTION
Added:
* Ubuntu Noble (24.04 LTS pre-release)
* Debian Trixie (testing)

Dropped:
* Debian Buster (oldoldstable)
* Debian Bullseye (oldstable)

Retained:
* Ubuntu Focal (20.04 LTS)
* Ubuntu Jammy (22.04 LTS)
* Debian Bookworm (stable)

Since we're still supporting RHEL 8 on Python 3.6 I don't see a reason to raise the minimum python3 version for deb-based distributions.

Ref: https://github.com/ros2/ros2/issues/1511