### PR TITLE
Declare dependency on setuptools in stdeb.

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -3,7 +3,7 @@ Debian-Version: 100
 ; catkin-pkg-modules same version as in:
 ; - setup.py
 ; - src/catkin_pkg/__init__.py
-Depends3: python3-catkin-pkg-modules (>= 1.0.0), python3-dateutil, python3-docutils
+Depends3: python3-catkin-pkg-modules (>= 1.0.0), python3-dateutil, python3-docutils, python3-setuptools
 Conflicts3: catkin, python-catkin-pkg
 Copyright-File: LICENSE
 Suite3: focal jammy buster bullseye bookworm


### PR DESCRIPTION
setuptools was previously all but guaranteed on python systems even if it was never explicitly required. It's possible to install catkin_pkg on a noble system which lacks setuptools.

I believe we're using it for the entrypoints behavior and there may be a stdlib or other alternative dependency we can use in the future.