### PR TITLE
Move flake8 import into test

### DIFF
--- a/test/test_flake8.py
+++ b/test/test_flake8.py
@@ -17,13 +17,14 @@ from __future__ import print_function
 import os
 import sys
 
-from flake8.api.legacy import get_style_guide
 import pytest
 
 
 @pytest.mark.flake8
 @pytest.mark.linter
 def test_flake8():
+    from flake8.api.legacy import get_style_guide
+
     # Configure flake8 using the .flake8 file in the root of this repository.
     style_guide = get_style_guide()
 


### PR DESCRIPTION
This will allow you to ignore the test using a label exclusion pattern without the flake8 dependency present, i.e. `pytest -m 'not linter'`