### PR TITLE
Switch to a raw string for the prepare_release cli.

### DIFF
--- a/src/catkin_pkg/cli/prepare_release.py
+++ b/src/catkin_pkg/cli/prepare_release.py
@@ -231,7 +231,7 @@ def _main():
     parser.add_argument('-y', '--non-interactive', action='store_true', default=False, help="Run without user interaction, confirming all questions with 'yes'")
     args = parser.parse_args()
 
-    if args.version and not re.match('^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$', args.version):
+    if args.version and not re.match(r'^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$', args.version):
         parser.error('The passed version must follow the conventions (positive integers x.y.z with no leading zeros)')
 
     if args.tag_prefix and ' ' in args.tag_prefix:


### PR DESCRIPTION
Otherwise, when running against Python 3.12, we see warnings like SyntaxWarning: invalid escape sequence '\.'

This should fix warnings that we see in jobs like https://build.ros2.org/view/Queue/job/Rsrc_uN__ackermann_msgs__ubuntu_noble__source/1/console