### PR TITLE
Support PEP 338 invocation of catkin_pkg modules

### DIFF
--- a/src/catkin_pkg/cli/create_pkg.py
+++ b/src/catkin_pkg/cli/create_pkg.py
@@ -68,3 +68,7 @@ def main(argv=sys.argv[1:], parent_path=os.getcwd()):
         print('Successfully created files in %s. Please adjust the values in package.xml.' % target_path)
     except ValueError as vae:
         parser.error(str(vae))
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/src/catkin_pkg/cli/find_pkg.py
+++ b/src/catkin_pkg/cli/find_pkg.py
@@ -27,3 +27,7 @@ def main(argv=sys.argv[1:]):
     except RuntimeError as e:
         print('ERROR: ' + str(e), file=sys.stderr)
         sys.exit(1)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/src/catkin_pkg/cli/generate_changelog.py
+++ b/src/catkin_pkg/cli/generate_changelog.py
@@ -135,3 +135,7 @@ def main_catching_runtime_error(*args, **kwargs):
     except RuntimeError as e:
         print('ERROR: ' + str(e), file=sys.stderr)
         sys.exit(1)
+
+
+if __name__ == '__main__':
+    sys.exit(main_catching_runtime_error())

--- a/src/catkin_pkg/cli/package_version.py
+++ b/src/catkin_pkg/cli/package_version.py
@@ -37,3 +37,7 @@ def main():
             print('%s -> %s' % (version, new_version))
     except Exception as e:  # noqa: B902
         sys.exit(str(e))
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/src/catkin_pkg/cli/prepare_release.py
+++ b/src/catkin_pkg/cli/prepare_release.py
@@ -449,3 +449,7 @@ def _main():
             print(fmt('@{yf}%s' % msg))
         else:
             raise RuntimeError(fmt('@{rf}%s' % msg))
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/src/catkin_pkg/cli/tag_changelog.py
+++ b/src/catkin_pkg/cli/tag_changelog.py
@@ -112,3 +112,7 @@ def main(sysargs=None):
     for (changelog_path, data) in new_changelog_data:
         with open(changelog_path, 'wb') as f:
             f.write(data.encode('utf-8'))
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/src/catkin_pkg/cli/test_changelog.py
+++ b/src/catkin_pkg/cli/test_changelog.py
@@ -44,3 +44,7 @@ def main(sysargs=None):
     changelog = Changelog()
     with open(changelog_file, 'r') as f:
         print(populate_changelog_from_rst(changelog, f.read()))
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
This reverts part of f7dcb41c4c91bc18a29931eb4633ddd71fb58a0a, which originally changed catkin_pkg to use 'console_scripts' instead of bare 'scripts' files.

PEP 338 invocation can be useful when invoking catkin_pkg functionality with a specific interpreter, or without using setuptools to create the 'console_scripts' executables.