### PR TITLE
Allow build metadata in the version string by appending a plus sign

### DIFF
--- a/src/catkin_pkg/package.py
+++ b/src/catkin_pkg/package.py
@@ -251,7 +251,7 @@ class Package(object):
                     'Package name "%s" does not follow the naming conventions. It should start with '
                     'a lower case letter and only contain lower case letters, digits, underscores, and dashes.' % self.name)
 
-        version_regexp = r'^[0-9]+\.[0-9]+\.[0-9]+$'
+        version_regexp = r'^[0-9]+\.[0-9]+\.[0-9]+(\+[a-zA-Z0-9_.-]+)?$'
         if not self.version:
             errors.append('Package version must not be empty')
         elif not re.match(version_regexp, self.version):


### PR DESCRIPTION
This PR changes the version conventions check regular expression to allow for version strings with build metadata values.

Build metadata values are version strings with appended plus signs and a series of dot separated identifiers immediately following the patch or pre-release version. For example `1.0.0+build.001`. See the semantic versioning doc bullet 10 ([here](https://semver.org/#spec-item-10)) for more details. Note, version strings with build metadata values are valid versions for `pip`.

Alternatively, the regular expression could be update to use the suggested regex in the semantic version doc ([here](https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string)).

I use the build metadata version when I have forked a repo and want to test experimental changes that I fully package and install with the package manager. It is nice to use the build metadata version value so there are not any version conflicts from upstream updated version values. In order to do this I need to update the `catkin_pkg` package repo with this change so that `colcon build` does not error out.