### PR TITLE
Print an error level message if package does not start with a letter

### DIFF
--- a/src/catkin_pkg/package.py
+++ b/src/catkin_pkg/package.py
@@ -243,7 +243,7 @@ class Package(object):
         if not self.name:
             errors.append('Package name must not be empty')
         # accepting upper case letters and hyphens only for backward compatibility
-        if not re.match('^[a-zA-Z0-9][a-zA-Z0-9_-]*$', self.name):
+        if not re.match('^[a-zA-Z][a-zA-Z0-9_-]*$', self.name):
             errors.append('Package name "%s" does not follow naming conventions' % self.name)
         else:
             if not re.match('^[a-z][a-z0-9_-]*$', self.name):


### PR DESCRIPTION
While doing some adversarial testing, we found that we could attempt to create a ROS 2 C++ package that starts with a letter and ament would print a warning level message (I believe using catkin's package naming checks). There would be subsequent  compilation errors of course, but it would be good to flag this as an Error earlier if possible.

```
WARNING: Package name "1test" does not follow the naming conventions. It should start with a lower case letter and only contain lower case letters, digits, underscores, and dashes.
```

Is there a reason the error level check allows for starting with a number?