### PR TITLE
Add a note on use in ROS 2 in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,6 +3,8 @@ catkin_pkg
 
 Standalone Python library for the `Catkin package system <http://ros.org/wiki/catkin>`_.
 
+> [!NOTE]  
+> Despite its name, the library is used also in ROS 2 context for managing `Ament packages <https://docs.ros.org/en/rolling/Concepts/Advanced/About-Build-System.html#term-ament-package>`. 
 
 Code & tickets
 --------------


### PR DESCRIPTION
I am not familiar with maintenance of ROS 2, and I was a bit confused by the user of `catkin_pkg` in ROS 2 context (see for example https://docs.ros.org/en/rolling/How-To-Guides/Core-maintainer-guide.html#source-release), as I always associated `catkin` to ROS 1. 

However, from what I understand this is how things I done, so I added a note on this to the repo README to clarify this for non-expert users (like me). Feel free to bikeshed the exact wording or the location of this documentation.