### PR TITLE
Remove spurious global declaration.

### DIFF
--- a/src/catkin_pkg/terminal_color.py
+++ b/src/catkin_pkg/terminal_color.py
@@ -42,13 +42,11 @@ _ansi = {}
 
 def ansi(key):
     """Return the escape sequence for a given ansi color key."""
-    global _ansi
     return _ansi[key]
 
 
 def enable_ANSI_colors():
     """Populate the global module dictionary `ansi` with ANSI escape sequences."""
-    global _ansi
     color_order = [
         'black', 'red', 'green', 'yellow', 'blue', 'purple', 'cyan', 'white'
     ]
@@ -88,7 +86,6 @@ def enable_ANSI_colors():
 
 def disable_ANSI_colors():
     """Set all the ANSI escape sequences to empty strings, effectively disabling console colors."""
-    global _ansi
     for key in _ansi:
         _ansi[key] = ''
 
@@ -117,7 +114,6 @@ def sanitize(msg):
 
 def fmt(msg):
     """Replace color annotations with ansi escape sequences."""
-    global _ansi
     msg = msg.replace('@!', '@{boldon}')
     msg = msg.replace('@/', '@{italicson}')
     msg = msg.replace('@_', '@{ulon}')

--- a/src/catkin_pkg/terminal_color.py
+++ b/src/catkin_pkg/terminal_color.py
@@ -54,12 +54,13 @@ def enable_ANSI_colors():
         'black': 'k', 'red': 'r', 'green': 'g', 'yellow': 'y', 'blue': 'b',
         'purple': 'p', 'cyan': 'c', 'white': 'w'
     }
-    _ansi = {
+    # In python3.9+ syntax this could be `_ansi |= ...`
+    _ansi.update({
         'escape': '\033', 'reset': 0, '|': 0,
         'boldon': 1, '!': 1, 'italicson': 3, '/': 3, 'ulon': 4, '_': 4,
         'invon': 7, 'boldoff': 22, 'italicsoff': 23,
         'uloff': 24, 'invoff': 27
-    }
+    })
 
     # Convert plain numbers to escapes
     for key in _ansi:


### PR DESCRIPTION
_ansi is not currently used as a global (it is a module variable in this file only and flake8 now catches and lints this unneeded declaration.