### PR TITLE
Drop runtime dependency on setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,6 @@ kwargs = {
         'packaging',
         'python-dateutil',
         'pyparsing',
-        'setuptools',
     ],
     'extras_require': {
         'test': [

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -3,7 +3,7 @@ Debian-Version: 100
 ; catkin-pkg-modules same version as in:
 ; - setup.py
 ; - src/catkin_pkg/__init__.py
-Depends3: python3-catkin-pkg-modules (>= 1.1.0), python3-dateutil, python3-docutils, python3-setuptools
+Depends3: python3-catkin-pkg-modules (>= 1.1.0), python3-dateutil, python3-docutils
 Conflicts3: catkin, python-catkin-pkg
 Copyright-File: LICENSE
 Suite3: focal jammy noble bookworm trixie


### PR DESCRIPTION
I can see no other use of `setuptools` or `pkg_resources` in `catkin_pkg`.

Fixes #374