### PR TITLE
Fixed VCS detection in git worktrees

### DIFF
--- a/src/catkin_pkg/workspace_vcs.py
+++ b/src/catkin_pkg/workspace_vcs.py
@@ -38,7 +38,7 @@ import subprocess
 
 def get_repository_type(path):
     for vcs_type in ['bzr', 'git', 'hg', 'svn']:
-        if os.path.isdir(os.path.join(path, '.%s' % vcs_type)):
+        if os.path.exists(os.path.join(path, '.%s' % vcs_type)):
             return vcs_type
     return None
 


### PR DESCRIPTION
When running `catkin_prepare_release` in a Git directory which is a worktree, I get:

```
$ catkin_prepare_release --bump major
Prepare the source repository for a release.
Could not determine repository type of '.'
```

This is because the VCS detection expects `.git` to be a folder. However, in a worktree, this is not true.

```
$ file .git
.git: ASCII text

$ LANG=C ll .git
-rw-rw-r-- 1 peci1 peci1 71 Jul 16 15:03 .git

$ cat .git
gitdir: /media/data/subt/common/src/ros-utils/.git/worktrees/ros-utils
```

This PR fixes the detection. I'm not sure what unexpected consequences it can have, but I guess quite minor.